### PR TITLE
feat(sandbox): model seccomp, host-env inheritance, bind sources, and egress

### DIFF
--- a/safeclaw-service/safeclaw/api/routes.py
+++ b/safeclaw-service/safeclaw/api/routes.py
@@ -407,7 +407,9 @@ async def evaluate_sandbox_policy(
                         "message": "Bind mount must specify a host source path",
                     }
                 )
-            elif mount.get("sourceValidated") is False:
+            elif mount.get("sourceValidated") is not True:
+                # Fail-closed: a bind mount source is UNVALIDATED unless explicitly
+                # proven validated. Both an omitted flag and an explicit false are flagged.
                 violations.append(
                     {
                         "field": f"filesystemPolicy.mounts[{i}].sourceValidated",

--- a/safeclaw-service/safeclaw/api/routes.py
+++ b/safeclaw-service/safeclaw/api/routes.py
@@ -360,6 +360,75 @@ async def evaluate_sandbox_policy(
                     }
                 )
 
+    # --- OpenClaw 2026.6.x sandbox hardening dimensions ---
+
+    # Seccomp profile: when a seccomp policy is declared it must not disable
+    # syscall filtering (unconfined). Absence is handled by other defaults.
+    seccomp = policy.get("seccompPolicy")
+    if isinstance(seccomp, dict):
+        profile = seccomp.get("profile")
+        if not profile:
+            violations.append(
+                {
+                    "field": "seccompPolicy.profile",
+                    "message": "Sandbox must declare a seccomp profile",
+                }
+            )
+        elif str(profile).lower() in ("unconfined", "disabled", "none", "off"):
+            violations.append(
+                {
+                    "field": "seccompPolicy.profile",
+                    "message": "Seccomp profile must not be unconfined or disabled",
+                }
+            )
+
+    # Host environment inheritance leaks host credentials into the sandbox.
+    env_policy = policy.get("environmentPolicy", {})
+    if isinstance(env_policy, dict) and env_policy.get("inheritHostEnv") is True:
+        violations.append(
+            {
+                "field": "environmentPolicy.inheritHostEnv",
+                "message": "Sandbox must not inherit host environment variables (credential leak)",
+            }
+        )
+
+    # Bind mounts must declare a validated host source path, especially when writable.
+    if isinstance(mounts, list):
+        for i, mount in enumerate(mounts):
+            if not isinstance(mount, dict):
+                continue
+            is_bind = mount.get("type") == "bind" or "source" in mount
+            if not is_bind:
+                continue
+            if not mount.get("source"):
+                violations.append(
+                    {
+                        "field": f"filesystemPolicy.mounts[{i}].source",
+                        "message": "Bind mount must specify a host source path",
+                    }
+                )
+            elif mount.get("sourceValidated") is False:
+                violations.append(
+                    {
+                        "field": f"filesystemPolicy.mounts[{i}].sourceValidated",
+                        "message": (
+                            "Bind mount source must be validated against the allowed source set"
+                        ),
+                    }
+                )
+
+    # Outbound egress requires an explicit allowlist.
+    net_policy = policy.get("networkPolicy", {})
+    if isinstance(net_policy, dict) and net_policy.get("allowOutbound") is True:
+        allowlist = net_policy.get("egressAllowlist")
+        if not allowlist:
+            violations.append(
+                {
+                    "field": "networkPolicy.egressAllowlist",
+                    "message": "Outbound egress requires an explicit egress allowlist",
+                }
+            )
+
     return SandboxPolicyValidationResponse(
         conformant=len(violations) == 0,
         violations=violations,

--- a/safeclaw-service/safeclaw/ontologies/safeclaw-sandbox.ttl
+++ b/safeclaw-service/safeclaw/ontologies/safeclaw-sandbox.ttl
@@ -34,6 +34,40 @@ sc:MountPoint a owl:Class ;
     rdfs:subClassOf sc:FilesystemPolicy ;
     rdfs:label "Mount Point" .
 
+# === Hardening classes (OpenClaw 2026.6.x sandbox dimensions) ===
+
+# These are standalone sandbox facet classes (NOT subclasses of SandboxPolicy/
+# MountPoint/NetworkPolicy) so the SandboxPolicyShape and MountPointShape do not
+# transitively apply their required-field constraints to them.
+
+sc:SeccompPolicy a owl:Class ;
+    rdfs:label "Seccomp Policy" ;
+    rdfs:comment "Policy governing the seccomp syscall-filtering profile of a sandbox" .
+
+sc:EnvironmentPolicy a owl:Class ;
+    rdfs:label "Environment Policy" ;
+    rdfs:comment "Policy governing host environment-variable inheritance (credential leak surface)" .
+
+sc:BindMount a owl:Class ;
+    rdfs:label "Bind Mount" ;
+    rdfs:comment "A host bind mount whose source path must be validated, especially when writable" .
+
+sc:EgressPolicy a owl:Class ;
+    rdfs:label "Egress Policy" ;
+    rdfs:comment "Policy governing outbound network egress and its allowlist" .
+
+sc:hasSeccompPolicy a owl:ObjectProperty ;
+    rdfs:domain sc:SandboxPolicy ;
+    rdfs:range sc:SeccompPolicy .
+
+sc:hasEnvironmentPolicy a owl:ObjectProperty ;
+    rdfs:domain sc:SandboxPolicy ;
+    rdfs:range sc:EnvironmentPolicy .
+
+sc:hasEgressPolicy a owl:ObjectProperty ;
+    rdfs:domain sc:NetworkPolicy ;
+    rdfs:range sc:EgressPolicy .
+
 sc:hasToolPolicy a owl:ObjectProperty ;
     rdfs:domain sc:SandboxPolicy ;
     rdfs:range sc:ToolPolicy .
@@ -66,3 +100,35 @@ sc:allowedHost a owl:DatatypeProperty ;
 sc:allowedPort a owl:DatatypeProperty ;
     rdfs:domain sc:NetworkPolicy ;
     rdfs:range xsd:integer .
+
+# === Hardening properties (OpenClaw 2026.6.x sandbox dimensions) ===
+
+sc:seccompProfile a owl:DatatypeProperty ;
+    rdfs:domain sc:SeccompPolicy ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Seccomp profile name. 'unconfined' (or disabled) removes syscall filtering and is rejected." .
+
+sc:inheritsHostEnv a owl:DatatypeProperty ;
+    rdfs:domain sc:EnvironmentPolicy ;
+    rdfs:range xsd:boolean ;
+    rdfs:comment "Whether the sandbox inherits the host process environment. true leaks host credentials and is rejected." .
+
+sc:bindSource a owl:DatatypeProperty ;
+    rdfs:domain sc:BindMount ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Validated absolute host source path for a bind mount. Required, especially for writable binds." .
+
+sc:bindSourceValidated a owl:DatatypeProperty ;
+    rdfs:domain sc:BindMount ;
+    rdfs:range xsd:boolean ;
+    rdfs:comment "Whether the bind mount source path has been validated against the allowed source set." .
+
+sc:allowsOutbound a owl:DatatypeProperty ;
+    rdfs:domain sc:EgressPolicy ;
+    rdfs:range xsd:boolean ;
+    rdfs:comment "Whether the sandbox permits outbound network egress." .
+
+sc:egressAllowlist a owl:DatatypeProperty ;
+    rdfs:domain sc:EgressPolicy ;
+    rdfs:range xsd:string ;
+    rdfs:comment "An allowlisted outbound egress destination. Required when outbound egress is allowed." .

--- a/safeclaw-service/safeclaw/ontologies/shapes/sandbox-shapes.ttl
+++ b/safeclaw-service/safeclaw/ontologies/shapes/sandbox-shapes.ttl
@@ -141,7 +141,9 @@ sc:BindMountShape a sh:NodeShape ;
         sh:prefixes <http://safeclaw.uku.ai/ontology/agent#> ;
         sh:select """
             SELECT $this
-            WHERE { $this sc:bindSourceValidated false . }
+            WHERE {
+                FILTER NOT EXISTS { $this sc:bindSourceValidated true }
+            }
         """
     ] .
 

--- a/safeclaw-service/safeclaw/ontologies/shapes/sandbox-shapes.ttl
+++ b/safeclaw-service/safeclaw/ontologies/shapes/sandbox-shapes.ttl
@@ -2,9 +2,17 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 # === Sandbox Policy Shapes ===
 # SHACL constraints for validating sandbox policy configurations.
+
+# Prefix declaration object so sh:sparql constraints can resolve sc:.
+<http://safeclaw.uku.ai/ontology/agent#> a owl:Ontology ;
+    sh:declare [
+        sh:prefix "sc" ;
+        sh:namespace "http://safeclaw.uku.ai/ontology/agent#"^^xsd:anyURI
+    ] .
 
 sc:SandboxPolicyShape a sh:NodeShape ;
     sh:targetClass sc:SandboxPolicy ;
@@ -66,4 +74,90 @@ sc:AllowedToolShape a sh:NodeShape ;
         sh:datatype xsd:string ;
         sh:name "tool name" ;
         sh:message "Allowed tool must specify a name"
+    ] .
+
+# === Hardening shapes (OpenClaw 2026.6.x sandbox dimensions) ===
+
+# Seccomp: a profile must be declared and must not be 'unconfined'/'disabled'.
+sc:SeccompPolicyShape a sh:NodeShape ;
+    sh:targetClass sc:SeccompPolicy ;
+    rdfs:label "Seccomp Policy Shape" ;
+    rdfs:comment "Requires a non-unconfined seccomp profile so syscall filtering stays enabled" ;
+    sh:property [
+        sh:path sc:seccompProfile ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "seccomp profile" ;
+        sh:message "Sandbox must declare a seccomp profile"
+    ] ;
+    sh:sparql [
+        sh:message "Seccomp profile must not be unconfined or disabled" ;
+        sh:prefixes <http://safeclaw.uku.ai/ontology/agent#> ;
+        sh:select """
+            SELECT $this
+            WHERE {
+                $this sc:seccompProfile ?profile .
+                FILTER ( LCASE(STR(?profile)) IN ( "unconfined", "disabled", "none", "off" ) )
+            }
+        """
+    ] .
+
+# Host environment inheritance leaks host credentials into the sandbox.
+sc:EnvironmentPolicyShape a sh:NodeShape ;
+    sh:targetClass sc:EnvironmentPolicy ;
+    rdfs:label "Environment Policy Shape" ;
+    rdfs:comment "Rejects host environment inheritance to prevent credential leakage" ;
+    sh:property [
+        sh:path sc:inheritsHostEnv ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:boolean ;
+        sh:name "host env inheritance"
+    ] ;
+    sh:sparql [
+        sh:message "Sandbox must not inherit host environment variables (credential leak)" ;
+        sh:prefixes <http://safeclaw.uku.ai/ontology/agent#> ;
+        sh:select """
+            SELECT $this
+            WHERE { $this sc:inheritsHostEnv true . }
+        """
+    ] .
+
+# Bind mounts must declare a validated source path, especially when writable.
+sc:BindMountShape a sh:NodeShape ;
+    sh:targetClass sc:BindMount ;
+    rdfs:label "Bind Mount Shape" ;
+    rdfs:comment "Requires a validated bind source path for host bind mounts" ;
+    sh:property [
+        sh:path sc:bindSource ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "bind source" ;
+        sh:message "Bind mount must specify a host source path"
+    ] ;
+    sh:sparql [
+        sh:message "Bind mount source must be validated against the allowed source set" ;
+        sh:prefixes <http://safeclaw.uku.ai/ontology/agent#> ;
+        sh:select """
+            SELECT $this
+            WHERE { $this sc:bindSourceValidated false . }
+        """
+    ] .
+
+# When outbound egress is allowed, an explicit allowlist is mandatory.
+sc:EgressPolicyShape a sh:NodeShape ;
+    sh:targetClass sc:EgressPolicy ;
+    rdfs:label "Egress Policy Shape" ;
+    rdfs:comment "Requires an egress allowlist whenever outbound egress is permitted" ;
+    sh:sparql [
+        sh:message "Outbound egress requires an explicit egress allowlist" ;
+        sh:prefixes <http://safeclaw.uku.ai/ontology/agent#> ;
+        sh:select """
+            SELECT $this
+            WHERE {
+                $this sc:allowsOutbound true .
+                FILTER NOT EXISTS { $this sc:egressAllowlist ?dest }
+            }
+        """
     ] .

--- a/safeclaw-service/tests/test_sandbox_shapes.py
+++ b/safeclaw-service/tests/test_sandbox_shapes.py
@@ -343,6 +343,48 @@ def test_bind_source_unvalidated_rejected():
 
 
 @requires_sandbox
+def test_bind_source_omitted_flag_rejected():
+    """A bind mount with a source but NO validation flag must fail (fail-closed)."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_bind_omitted_flag"]
+    g.add((node, RDF.type, SC.BindMount))
+    g.add((node, SC.mountPath, Literal("/workspace", datatype=XSD.string)))
+    g.add((node, SC.mountMode, Literal("read-write")))
+    g.add((node, SC.bindSource, Literal("/host/secrets", datatype=XSD.string)))
+    # NOTE: no bindSourceValidated triple at all -> must be treated as unvalidated.
+
+    result = validator.validate(g)
+    assert result.conforms is False, "Omitted validation flag must be non-conformant (fail-closed)"
+    messages = [v["message"].lower() for v in result.violations]
+    assert any("source" in m and "validat" in m for m in messages)
+
+
+@requires_sandbox
+def test_bind_source_validated_true_conformant():
+    """A bind mount explicitly proven validated (true) must still conform."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_bind_validated"]
+    g.add((node, RDF.type, SC.BindMount))
+    g.add((node, SC.mountPath, Literal("/workspace", datatype=XSD.string)))
+    g.add((node, SC.mountMode, Literal("read-write")))
+    g.add((node, SC.bindSource, Literal("/srv/workspace", datatype=XSD.string)))
+    g.add((node, SC.bindSourceValidated, Literal(True)))
+
+    result = validator.validate(g)
+    assert result.conforms is True, f"Expected conformant, got: {result.violations}"
+
+
+@requires_sandbox
 def test_bind_source_missing_rejected():
     """A bind mount without a source path should fail validation."""
     validator = SHACLValidator()
@@ -628,6 +670,43 @@ def test_api_sandbox_bind_source_unvalidated(client):
     data = resp.json()
     assert data["conformant"] is False
     assert any("sourceValidated" in v["field"] for v in data["violations"])
+
+
+def test_api_sandbox_bind_source_omitted_flag(client):
+    """A bind mount with a source but NO sourceValidated flag must be flagged (fail-closed)."""
+    policy = _base_policy()
+    policy["filesystemPolicy"]["mounts"] = [
+        {
+            "path": "/workspace",
+            "mode": "read-write",
+            "type": "bind",
+            "source": "/host/secrets",
+            # NOTE: no sourceValidated key at all.
+        }
+    ]
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is False, "Omitted sourceValidated must fail-closed"
+    assert any("sourceValidated" in v["field"] for v in data["violations"])
+
+
+def test_api_sandbox_bind_source_validated_true_ok(client):
+    """A bind mount with sourceValidated=True must still conform (no over-blocking)."""
+    policy = _base_policy()
+    policy["filesystemPolicy"]["mounts"] = [
+        {
+            "path": "/workspace",
+            "mode": "read-write",
+            "type": "bind",
+            "source": "/srv/workspace",
+            "sourceValidated": True,
+        }
+    ]
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is True, data["violations"]
 
 
 def test_api_sandbox_egress_without_allowlist(client):

--- a/safeclaw-service/tests/test_sandbox_shapes.py
+++ b/safeclaw-service/tests/test_sandbox_shapes.py
@@ -233,6 +233,172 @@ def test_denied_tool_missing_name():
     assert any("name" in m.lower() or "tool" in m.lower() for m in messages)
 
 
+# ── Hardening ontology tests (OpenClaw 2026.6.x dimensions, #323) ──
+
+
+@requires_sandbox
+def test_sandbox_hardening_properties_queryable():
+    """Verify the new hardening properties are present in the ontology."""
+    g = Graph()
+    g.bind("sc", SC)
+    g.parse(str(_sandbox_ttl), format="turtle")
+
+    for prop in [
+        SC.seccompProfile,
+        SC.inheritsHostEnv,
+        SC.bindSource,
+        SC.egressAllowlist,
+    ]:
+        results = list(g.triples((prop, RDF.type, None)))
+        assert len(results) > 0, f"Property {prop} not found"
+
+
+@requires_sandbox
+def test_sandbox_hardening_classes_queryable():
+    """Verify the new hardening classes are present in the ontology."""
+    g = Graph()
+    g.bind("sc", SC)
+    g.parse(str(_sandbox_ttl), format="turtle")
+
+    for cls in [SC.SeccompPolicy, SC.EnvironmentPolicy, SC.BindMount, SC.EgressPolicy]:
+        results = list(g.triples((cls, RDF.type, None)))
+        assert len(results) > 0, f"Class {cls} not found"
+
+
+@requires_sandbox
+def test_seccomp_unconfined_rejected():
+    """A seccomp profile set to 'unconfined' should fail validation."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_seccomp_unconfined"]
+    g.add((node, RDF.type, SC.SeccompPolicy))
+    g.add((node, SC.seccompProfile, Literal("unconfined", datatype=XSD.string)))
+
+    result = validator.validate(g)
+    assert result.conforms is False
+    messages = [v["message"].lower() for v in result.violations]
+    assert any("unconfined" in m or "seccomp" in m for m in messages)
+
+
+@requires_sandbox
+def test_seccomp_profile_conformant():
+    """A non-unconfined seccomp profile should conform."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_seccomp_ok"]
+    g.add((node, RDF.type, SC.SeccompPolicy))
+    g.add((node, SC.seccompProfile, Literal("default", datatype=XSD.string)))
+
+    result = validator.validate(g)
+    assert result.conforms is True, f"Expected conformant, got: {result.violations}"
+
+
+@requires_sandbox
+def test_host_env_inheritance_rejected():
+    """A sandbox inheriting host env vars should fail validation (credential leak)."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_env_inherit"]
+    g.add((node, RDF.type, SC.EnvironmentPolicy))
+    g.add((node, SC.inheritsHostEnv, Literal(True)))
+
+    result = validator.validate(g)
+    assert result.conforms is False
+    messages = [v["message"].lower() for v in result.violations]
+    assert any("host environment" in m or "credential" in m for m in messages)
+
+
+@requires_sandbox
+def test_bind_source_unvalidated_rejected():
+    """A bind mount with an unvalidated source should fail validation."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_bind_unvalidated"]
+    g.add((node, RDF.type, SC.BindMount))
+    g.add((node, SC.mountPath, Literal("/workspace", datatype=XSD.string)))
+    g.add((node, SC.mountMode, Literal("read-write")))
+    g.add((node, SC.bindSource, Literal("/host/secrets", datatype=XSD.string)))
+    g.add((node, SC.bindSourceValidated, Literal(False)))
+
+    result = validator.validate(g)
+    assert result.conforms is False
+    messages = [v["message"].lower() for v in result.violations]
+    assert any("source" in m and "validat" in m for m in messages)
+
+
+@requires_sandbox
+def test_bind_source_missing_rejected():
+    """A bind mount without a source path should fail validation."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_bind_no_source"]
+    g.add((node, RDF.type, SC.BindMount))
+    g.add((node, SC.mountPath, Literal("/workspace", datatype=XSD.string)))
+    g.add((node, SC.mountMode, Literal("read-write")))
+
+    result = validator.validate(g)
+    assert result.conforms is False
+    messages = [v["message"].lower() for v in result.violations]
+    assert any("source" in m for m in messages)
+
+
+@requires_sandbox
+def test_egress_without_allowlist_rejected():
+    """Outbound egress without an allowlist should fail validation."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_egress_open"]
+    g.add((node, RDF.type, SC.EgressPolicy))
+    g.add((node, SC.allowsOutbound, Literal(True)))
+
+    result = validator.validate(g)
+    assert result.conforms is False
+    messages = [v["message"].lower() for v in result.violations]
+    assert any("egress" in m and "allowlist" in m for m in messages)
+
+
+@requires_sandbox
+def test_egress_with_allowlist_conformant():
+    """Outbound egress with an allowlist should conform."""
+    validator = SHACLValidator()
+    validator.load_shapes(_shapes_dir)
+    validator._ont_graph.parse(str(_sandbox_ttl), format="turtle")
+
+    g = Graph()
+    g.bind("sc", SC)
+    node = SC["test_egress_allowlisted"]
+    g.add((node, RDF.type, SC.EgressPolicy))
+    g.add((node, SC.allowsOutbound, Literal(True)))
+    g.add((node, SC.egressAllowlist, Literal("api.example.com", datatype=XSD.string)))
+
+    result = validator.validate(g)
+    assert result.conforms is True, f"Expected conformant, got: {result.violations}"
+
+
 # ── API endpoint tests ──
 
 
@@ -389,3 +555,120 @@ def test_api_sandbox_policy_denied_tool_missing_name(client):
     data = resp.json()
     assert data["conformant"] is False
     assert any("denied" in v["field"] for v in data["violations"])
+
+
+# ── API hardening tests (OpenClaw 2026.6.x dimensions, #323) ──
+
+
+def _base_policy() -> dict:
+    return {
+        "toolPolicy": {"allowed": ["read"]},
+        "filesystemPolicy": {"mounts": [{"path": "/workspace", "mode": "read-write"}]},
+    }
+
+
+def test_api_sandbox_seccomp_unconfined(client):
+    """A seccomp profile of 'unconfined' should be flagged."""
+    policy = _base_policy()
+    policy["seccompPolicy"] = {"profile": "unconfined"}
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is False
+    assert any("seccomp" in v["field"].lower() for v in data["violations"])
+
+
+def test_api_sandbox_seccomp_default_ok(client):
+    """A non-unconfined seccomp profile should not be flagged."""
+    policy = _base_policy()
+    policy["seccompPolicy"] = {"profile": "default"}
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    assert resp.json()["conformant"] is True
+
+
+def test_api_sandbox_host_env_inheritance(client):
+    """Inheriting host env vars should be flagged as a credential leak."""
+    policy = _base_policy()
+    policy["environmentPolicy"] = {"inheritHostEnv": True}
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is False
+    assert any("inheritHostEnv" in v["field"] for v in data["violations"])
+
+
+def test_api_sandbox_bind_source_missing(client):
+    """A bind mount without a host source should be flagged."""
+    policy = _base_policy()
+    policy["filesystemPolicy"]["mounts"] = [
+        {"path": "/workspace", "mode": "read-write", "type": "bind"}
+    ]
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is False
+    assert any("source" in v["field"] for v in data["violations"])
+
+
+def test_api_sandbox_bind_source_unvalidated(client):
+    """A writable bind mount with an unvalidated source should be flagged."""
+    policy = _base_policy()
+    policy["filesystemPolicy"]["mounts"] = [
+        {
+            "path": "/workspace",
+            "mode": "read-write",
+            "type": "bind",
+            "source": "/host/secrets",
+            "sourceValidated": False,
+        }
+    ]
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is False
+    assert any("sourceValidated" in v["field"] for v in data["violations"])
+
+
+def test_api_sandbox_egress_without_allowlist(client):
+    """Outbound egress without an allowlist should be flagged."""
+    policy = _base_policy()
+    policy["networkPolicy"] = {"allowOutbound": True}
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is False
+    assert any("egressAllowlist" in v["field"] for v in data["violations"])
+
+
+def test_api_sandbox_egress_with_allowlist_ok(client):
+    """Outbound egress with an allowlist should pass."""
+    policy = _base_policy()
+    policy["networkPolicy"] = {
+        "allowOutbound": True,
+        "egressAllowlist": ["api.example.com"],
+    }
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    assert resp.json()["conformant"] is True
+
+
+def test_api_sandbox_fully_hardened_ok(client):
+    """A fully hardened sandbox policy should conform."""
+    policy = _base_policy()
+    policy["filesystemPolicy"]["mounts"] = [
+        {
+            "path": "/workspace",
+            "mode": "read-write",
+            "type": "bind",
+            "source": "/srv/workspace",
+            "sourceValidated": True,
+        }
+    ]
+    policy["seccompPolicy"] = {"profile": "default"}
+    policy["environmentPolicy"] = {"inheritHostEnv": False}
+    policy["networkPolicy"] = {"allowOutbound": True, "egressAllowlist": ["api.example.com"]}
+    resp = client.post("/api/v1/evaluate/sandbox-policy", json={"policy": policy})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conformant"] is True, data["violations"]


### PR DESCRIPTION
## Summary

OpenClaw `2026.6.x` added sandbox hardening dimensions that SafeClaw's sandbox ontology could not represent. `safeclaw-sandbox.ttl` modeled only tool/filesystem/network basics, and `/evaluate/sandbox-policy` still validated an older `toolPolicy`/`filesystemPolicy`-style shape, so it would not catch these dimensions. This PR adds the missing ontology classes/properties, matching SHACL shapes, and endpoint mapping for:

- **Seccomp profile** — `sc:SeccompPolicy` / `sc:seccompProfile`; rejects `unconfined`/`disabled`/`none`/`off`.
- **Host-environment inheritance (credential leak)** — `sc:EnvironmentPolicy` / `sc:inheritsHostEnv`; rejects inheriting the host env.
- **Bind-mount source validation** — `sc:BindMount` / `sc:bindSource` / `sc:bindSourceValidated`; requires a host source path and rejects unvalidated sources.
- **Outbound egress allowlist** — `sc:EgressPolicy` / `sc:allowsOutbound` / `sc:egressAllowlist`; requires an explicit allowlist when outbound egress is enabled.

### New ontology terms
- Classes: `sc:SeccompPolicy`, `sc:EnvironmentPolicy`, `sc:BindMount`, `sc:EgressPolicy`
- Object properties: `sc:hasSeccompPolicy`, `sc:hasEnvironmentPolicy`, `sc:hasEgressPolicy`
- Datatype properties: `sc:seccompProfile`, `sc:inheritsHostEnv`, `sc:bindSource`, `sc:bindSourceValidated`, `sc:allowsOutbound`, `sc:egressAllowlist`
- SHACL shapes: `sc:SeccompPolicyShape`, `sc:EnvironmentPolicyShape`, `sc:BindMountShape`, `sc:EgressPolicyShape`

### Design notes
- The new facet classes are **standalone** (not subclasses of `SandboxPolicy`/`MountPoint`/`NetworkPolicy`) so the existing required-field shapes don't transitively apply to them.
- Value/blocking constraints use `sh:sparql` because pySHACL does not reliably evaluate `sh:not [ sh:in ... ]` / `sh:not [ sh:hasValue ... ]`.
- Only the `/evaluate/sandbox-policy` endpoint in `routes.py` was changed (single hunk). `models.py` needed no change (`policy: dict` already accepts the new fields). NemoClaw egress modeling in `nemoclaw-policy.ttl` was left untouched per the ticket.

## Testing

All commands run from `safeclaw-service/` in the project venv.

```
python -m pytest tests/test_sandbox_shapes.py -q
# 34 passed

python -m pytest tests/ -q
# 906 passed, 1 warning in ~34s

ruff check safeclaw/ tests/
# All checks passed!

ruff format --check safeclaw/api/routes.py safeclaw/api/models.py tests/test_sandbox_shapes.py
# 3 files already formatted
```

Note: `ruff format --check` over the whole tree reports 8 pre-existing unrelated files needing reformatting (e.g. `tests/test_nemoclaw_integration.py`); none are touched by this PR.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)