### PR TITLE
feat(engine): plumb v2026.6.8 tool-call context, cron policy, LLM audit

### DIFF
--- a/openclaw-safeclaw-plugin/index.ts
+++ b/openclaw-safeclaw-plugin/index.ts
@@ -273,6 +273,14 @@ export default {
         toolName: event.toolName ?? '',
         params: event.params ?? {},
         runId: ctx.runId ?? '',
+        // v2026.6.8 discriminators so the service can classify code-mode exec,
+        // file-touching envelopes, etc. (#316)
+        toolKind: event.toolKind ?? '',
+        toolInputKind: event.toolInputKind ?? '',
+        derivedPaths: event.derivedPaths ?? [],
+        // Trigger origin (#324): cron-driven runs carry ctx.jobId.
+        triggeredBy: ctx.jobId ? 'cron' : 'interactive',
+        jobId: ctx.jobId ?? '',
       });
 
       if (r === null && cfg.failMode === 'closed' && cfg.enforcement === 'enforce') {

--- a/safeclaw-service/safeclaw/api/models.py
+++ b/safeclaw-service/safeclaw/api/models.py
@@ -43,6 +43,14 @@ class ToolCallRequest(BaseModel):
     agentToken: str = ""
     runId: str | None = None
     dryRun: bool = False
+    # OpenClaw v2026.6.8 before_tool_call discriminators (#316) — forwarded so
+    # the classifier can distinguish code-mode exec from shell exec, etc.
+    toolKind: str = ""
+    toolInputKind: str = ""
+    derivedPaths: list[str] = []
+    # Trigger origin (#324) — "cron" scheduled runs have no interactive approver.
+    triggeredBy: str = ""
+    jobId: str = ""
 
     @field_validator("params")
     @classmethod
@@ -103,6 +111,9 @@ class LlmIORequest(BaseModel):
     agentToken: str = ""
     provider: str = ""
     model: str = ""
+    # #315: audit-correlation context forwarded by the plugin (v2026.6.8).
+    runId: str = ""
+    usage: dict = {}
 
 
 class SessionEndRequest(BaseModel):

--- a/safeclaw-service/safeclaw/api/models.py
+++ b/safeclaw-service/safeclaw/api/models.py
@@ -115,6 +115,13 @@ class LlmIORequest(BaseModel):
     runId: str = ""
     usage: dict = {}
 
+    @field_validator("usage")
+    @classmethod
+    def check_usage(cls, v: dict) -> dict:
+        # usage is written verbatim into the audit JSONL under the audit lock;
+        # bound its depth/size like params so a caller cannot bloat audit files.
+        return _validate_params(v)
+
 
 class SessionEndRequest(BaseModel):
     sessionId: str

--- a/safeclaw-service/safeclaw/api/routes.py
+++ b/safeclaw-service/safeclaw/api/routes.py
@@ -631,6 +631,7 @@ async def record_subagent_ended(
 @router.post("/log/llm-input")
 async def log_llm_input(request: LlmIORequest):
     engine = _get_engine()
+    _verify_agent_token(engine, request.agentId, request.agentToken)
     event = LlmIOEvent(
         session_id=request.sessionId,
         direction="input",
@@ -649,6 +650,7 @@ async def log_llm_input(request: LlmIORequest):
 @router.post("/log/llm-output")
 async def log_llm_output(request: LlmIORequest):
     engine = _get_engine()
+    _verify_agent_token(engine, request.agentId, request.agentToken)
     event = LlmIOEvent(
         session_id=request.sessionId,
         direction="output",

--- a/safeclaw-service/safeclaw/api/routes.py
+++ b/safeclaw-service/safeclaw/api/routes.py
@@ -160,6 +160,35 @@ def _verify_agent_token(engine, agent_id: str | None, agent_token: str | None):
         raise HTTPException(status_code=403, detail="Invalid agent token")
 
 
+def _require_attributed_auth(engine, req: Request, agent_id: str | None, agent_token: str | None):
+    """Stricter auth for routes that persist raw caller-supplied content.
+
+    Unlike ``_verify_agent_token`` (which allows empty/unregistered agents for
+    backwards compatibility on the governance routes), the durable LLM I/O audit
+    writes record raw prompt/response content to disk. Allowing anonymous callers
+    there — which happens in local mode where the API-key middleware passes
+    through without setting ``org_id`` — leaves audit poisoning and unbounded log
+    growth open. Require *attributable* auth: an API-key org context, or a
+    registered agent presenting a valid token.
+    """
+    if getattr(req.state, "org_id", None):
+        return  # API-key authenticated (org context present)
+    if agent_id:
+        # A claimed agent identity must be registered AND present a valid token.
+        record = engine.agent_registry.get_agent(agent_id)
+        if (
+            record is not None
+            and agent_token
+            and engine.agent_registry.verify_token(agent_id, agent_token)
+        ):
+            return
+        raise HTTPException(status_code=403, detail="Invalid or unregistered agent token")
+    raise HTTPException(
+        status_code=401,
+        detail="LLM audit logging requires API-key or registered-agent authentication",
+    )
+
+
 @router.post("/evaluate/tool-call", response_model=DecisionResponse)
 async def evaluate_tool_call(request: ToolCallRequest, req: Request) -> DecisionResponse:
     engine = _get_engine()
@@ -629,9 +658,9 @@ async def record_subagent_ended(
 
 
 @router.post("/log/llm-input")
-async def log_llm_input(request: LlmIORequest):
+async def log_llm_input(request: LlmIORequest, req: Request):
     engine = _get_engine()
-    _verify_agent_token(engine, request.agentId, request.agentToken)
+    _require_attributed_auth(engine, req, request.agentId, request.agentToken)
     event = LlmIOEvent(
         session_id=request.sessionId,
         direction="input",
@@ -648,9 +677,9 @@ async def log_llm_input(request: LlmIORequest):
 
 
 @router.post("/log/llm-output")
-async def log_llm_output(request: LlmIORequest):
+async def log_llm_output(request: LlmIORequest, req: Request):
     engine = _get_engine()
-    _verify_agent_token(engine, request.agentId, request.agentToken)
+    _require_attributed_auth(engine, req, request.agentId, request.agentToken)
     event = LlmIOEvent(
         session_id=request.sessionId,
         direction="output",

--- a/safeclaw-service/safeclaw/api/routes.py
+++ b/safeclaw-service/safeclaw/api/routes.py
@@ -179,6 +179,11 @@ async def evaluate_tool_call(request: ToolCallRequest, req: Request) -> Decision
         agent_id=request.agentId,
         agent_token=request.agentToken,
         run_id=request.runId,
+        tool_kind=request.toolKind,
+        tool_input_kind=request.toolInputKind,
+        derived_paths=request.derivedPaths,
+        triggered_by=request.triggeredBy,
+        job_id=request.jobId,
     )
 
     # When dryRun is True, skip the full engine pipeline to avoid side effects
@@ -632,6 +637,10 @@ async def log_llm_input(request: LlmIORequest):
         content=request.content,
         agent_id=request.agentId,
         agent_token=request.agentToken,
+        provider=request.provider,
+        model=request.model,
+        run_id=request.runId,
+        usage=request.usage,
     )
     await engine.log_llm_io(event)
     return {"ok": True}
@@ -646,6 +655,10 @@ async def log_llm_output(request: LlmIORequest):
         content=request.content,
         agent_id=request.agentId,
         agent_token=request.agentToken,
+        provider=request.provider,
+        model=request.model,
+        run_id=request.runId,
+        usage=request.usage,
     )
     await engine.log_llm_io(event)
     return {"ok": True}

--- a/safeclaw-service/safeclaw/audit/logger.py
+++ b/safeclaw-service/safeclaw/audit/logger.py
@@ -7,7 +7,7 @@ import os
 import re
 import stat
 import threading
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from safeclaw.audit.models import DecisionRecord
@@ -179,6 +179,54 @@ class AuditLogger:
             logger.warning(log_msg)
         else:
             logger.info(log_msg)
+
+    def _get_llm_session_file(self, session_id: str) -> Path:
+        today = date.today().isoformat()
+        day_dir = self.audit_dir / today
+        self._ensure_dir(self.audit_dir)
+        self._ensure_dir(day_dir)
+        safe_id = self._safe_id(session_id)
+        return day_dir / f"llm-{safe_id}.jsonl"
+
+    def log_llm_io(
+        self,
+        session_id: str,
+        direction: str,
+        content: str,
+        *,
+        provider: str = "",
+        model: str = "",
+        run_id: str = "",
+        usage: dict | None = None,
+        max_content: int = 10_000,
+    ) -> None:
+        """Append an LLM input/output record to a per-session JSONL audit file.
+
+        This is a content/usage observability trail (not a governance
+        DecisionRecord), so it is written to a separate `llm-<session>.jsonl`
+        file without the decision hash chain. Content is truncated to bound
+        file growth; provider/model/run_id give attribution and correlation
+        that the prior debug-only log lacked (#315).
+        """
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "sessionId": session_id,
+            "direction": direction,
+            "provider": provider,
+            "model": model,
+            "runId": run_id,
+            "usage": usage or {},
+            "content": content[:max_content],
+            "truncated": len(content) > max_content,
+        }
+        line = json.dumps(record, separators=(",", ":")) + "\n"
+        filepath = self._get_llm_session_file(session_id)
+        with self._lock:
+            fd = os.open(str(filepath), os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
+            try:
+                os.write(fd, line.encode("utf-8"))
+            finally:
+                os.close(fd)
 
     def get_session_records(
         self,

--- a/safeclaw-service/safeclaw/engine/core.py
+++ b/safeclaw-service/safeclaw/engine/core.py
@@ -14,6 +14,18 @@ class ToolCallEvent:
     agent_id: str | None = None
     agent_token: str = ""
     run_id: str | None = None
+    # OpenClaw v2026.6.8 before_tool_call discriminators (consumed by the
+    # action classifier — see #316). tool_kind e.g. "code_mode_exec";
+    # tool_input_kind e.g. "javascript"/"typescript"; derived_paths are
+    # host-resolved target paths for file-touching envelopes (apply_patch).
+    tool_kind: str = ""
+    tool_input_kind: str = ""
+    derived_paths: list[str] = field(default_factory=list)
+    # Trigger origin (#324): "cron" for scheduled/autonomous runs (no
+    # interactive approver present), "interactive" otherwise. job_id is the
+    # OpenClaw cron job id when triggered_by == "cron".
+    triggered_by: str = ""
+    job_id: str = ""
 
 
 @dataclass
@@ -54,6 +66,13 @@ class LlmIOEvent:
     content: str
     agent_id: str | None = None
     agent_token: str = ""
+    # #315: provider/model/run_id/usage carry the audit context that the
+    # plugin now forwards (v2026.6.8). Without these the LLM I/O audit trail
+    # could not attribute a prompt/response to a model or correlate by run.
+    provider: str = ""
+    model: str = ""
+    run_id: str = ""
+    usage: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/safeclaw-service/safeclaw/engine/full_engine.py
+++ b/safeclaw-service/safeclaw/engine/full_engine.py
@@ -65,6 +65,7 @@ STEP_TEMPORAL_CHECK = "temporal_check"
 STEP_RATE_LIMIT_CHECK = "rate_limit_check"
 STEP_DERIVED_RULES = "derived_rules"
 STEP_HIERARCHY_RATE_LIMIT = "hierarchy_rate_limit"
+STEP_CRON_NO_APPROVER = "cron_no_approver"
 
 MAX_PENDING_TOOL_RESULT_SESSIONS = 1000
 MAX_PENDING_TOOL_RESULTS_PER_SESSION = 1000
@@ -544,7 +545,34 @@ class FullEngine(SafeClawEngine):
         event.tool_name = sanitize_string(event.tool_name)
         event.params = sanitize_params(event.params) if event.params else {}
         async with self._session_lock(event.session_id):
-            return await self._evaluate_tool_call_locked(event)
+            decision = await self._evaluate_tool_call_locked(event)
+        return self._apply_trigger_origin_policy(event, decision)
+
+    def _apply_trigger_origin_policy(self, event: ToolCallEvent, decision: Decision) -> Decision:
+        """Escalate confirmation-required decisions on autonomous (cron) runs.
+
+        A "needs confirmation" outcome assumes an interactive approver can say
+        yes/no. Scheduled/cron runs have no human in the loop (#324), so we fail
+        safe and block rather than silently allow or hang. The original audit
+        record (with its audit_id) is preserved for traceability; the returned
+        decision reflects the escalation.
+        """
+        if event.triggered_by == "cron" and decision.requires_confirmation:
+            escalated = Decision(
+                block=True,
+                reason=(
+                    "[SafeClaw] Action requires confirmation but this is a scheduled "
+                    "(cron) run with no interactive approver — blocked (fail-safe)"
+                ),
+                audit_id=decision.audit_id,
+                requires_confirmation=False,
+                constraint_step=STEP_CRON_NO_APPROVER,
+            )
+            # Preserve the dynamically-attached risk level so the API response
+            # still reports riskLevel for the escalated block.
+            escalated._risk_level = getattr(decision, "_risk_level", "")  # type: ignore[attr-defined]
+            return escalated
+        return decision
 
     async def _evaluate_tool_call_locked(self, event: ToolCallEvent) -> Decision:
         """Internal: runs the constraint pipeline under the session lock."""
@@ -1199,8 +1227,23 @@ class FullEngine(SafeClawEngine):
         logger.info(f"Session {session_id} cleared")
 
     async def log_llm_io(self, event: LlmIOEvent) -> None:
+        self.audit.log_llm_io(
+            session_id=event.session_id,
+            direction=event.direction,
+            content=event.content,
+            provider=event.provider,
+            model=event.model,
+            run_id=event.run_id,
+            usage=event.usage,
+        )
         logger.debug(
-            f"LLM {event.direction}: {event.content[:100]}{'...' if len(event.content) > 100 else ''}"
+            "LLM %s [provider=%s model=%s run=%s]: %s%s",
+            event.direction,
+            event.provider or "?",
+            event.model or "?",
+            event.run_id or "?",
+            event.content[:100],
+            "..." if len(event.content) > 100 else "",
         )
 
     def _fire_llm_tasks(

--- a/safeclaw-service/safeclaw/engine/full_engine.py
+++ b/safeclaw-service/safeclaw/engine/full_engine.py
@@ -545,33 +545,26 @@ class FullEngine(SafeClawEngine):
         event.tool_name = sanitize_string(event.tool_name)
         event.params = sanitize_params(event.params) if event.params else {}
         async with self._session_lock(event.session_id):
-            decision = await self._evaluate_tool_call_locked(event)
-        return self._apply_trigger_origin_policy(event, decision)
+            return await self._evaluate_tool_call_locked(event)
 
     def _apply_trigger_origin_policy(self, event: ToolCallEvent, decision: Decision) -> Decision:
         """Escalate confirmation-required decisions on autonomous (cron) runs.
 
         A "needs confirmation" outcome assumes an interactive approver can say
         yes/no. Scheduled/cron runs have no human in the loop (#324), so we fail
-        safe and block rather than silently allow or hang. The original audit
-        record (with its audit_id) is preserved for traceability; the returned
-        decision reflects the escalation.
+        safe and block rather than silently allow or hang. The decision is
+        mutated IN PLACE (and returned) so the durable audit record written by
+        ``_log_decision`` — and the decision returned to the caller — both
+        reflect the no-approver block rather than the original confirmation.
         """
-        if event.triggered_by == "cron" and decision.requires_confirmation:
-            escalated = Decision(
-                block=True,
-                reason=(
-                    "[SafeClaw] Action requires confirmation but this is a scheduled "
-                    "(cron) run with no interactive approver — blocked (fail-safe)"
-                ),
-                audit_id=decision.audit_id,
-                requires_confirmation=False,
-                constraint_step=STEP_CRON_NO_APPROVER,
+        if getattr(event, "triggered_by", "") == "cron" and decision.requires_confirmation:
+            decision.block = True
+            decision.requires_confirmation = False
+            decision.reason = (
+                "[SafeClaw] Action requires confirmation but this is a scheduled "
+                "(cron) run with no interactive approver — blocked (fail-safe)"
             )
-            # Preserve the dynamically-attached risk level so the API response
-            # still reports riskLevel for the escalated block.
-            escalated._risk_level = getattr(decision, "_risk_level", "")  # type: ignore[attr-defined]
-            return escalated
+            decision.constraint_step = STEP_CRON_NO_APPROVER
         return decision
 
     async def _evaluate_tool_call_locked(self, event: ToolCallEvent) -> Decision:
@@ -1402,6 +1395,13 @@ class FullEngine(SafeClawEngine):
         start_time: float,
         constraint_step: str = "",
     ) -> None:
+        # Apply the cron no-approver escalation BEFORE building the record so the
+        # durable audit entry reflects the actual block (and its constraint_step)
+        # rather than the superseded confirmation decision (#324).
+        decision = self._apply_trigger_origin_policy(event, decision)
+        if decision.constraint_step == STEP_CRON_NO_APPROVER:
+            constraint_step = STEP_CRON_NO_APPROVER
+
         elapsed_ms = (time.monotonic() - start_time) * 1000
         # BUG-004/035: Use server-side session history for audit records instead
         # of client-supplied event.session_history

--- a/safeclaw-service/tests/test_pr2_context_plumbing.py
+++ b/safeclaw-service/tests/test_pr2_context_plumbing.py
@@ -234,6 +234,24 @@ class TestLlmLogAuth:
             )
             assert ok.status_code == 200, path
 
+    def test_llm_log_rejects_anonymous_and_unregistered(self, client):
+        c, _ = client
+        for path in ("/api/v1/log/llm-input", "/api/v1/log/llm-output"):
+            # No org auth and no agent context -> 401 (no anonymous durable writes).
+            anon = c.post(path, json={"sessionId": "s", "content": "x"})
+            assert anon.status_code == 401, path
+            # An unregistered agentId is not attribution either -> 403.
+            unreg = c.post(
+                path,
+                json={
+                    "sessionId": "s",
+                    "content": "x",
+                    "agentId": "ghost",
+                    "agentToken": "whatever",
+                },
+            )
+            assert unreg.status_code == 403, path
+
     def test_llm_log_rejects_oversized_usage(self, client):
         c, _ = client
         huge_usage = {f"k{i}": "v" * 1000 for i in range(200)}  # > params size bound

--- a/safeclaw-service/tests/test_pr2_context_plumbing.py
+++ b/safeclaw-service/tests/test_pr2_context_plumbing.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 
 import pytest
+from starlette.testclient import TestClient
 
 from safeclaw.config import SafeClawConfig
 from safeclaw.engine.core import Decision, LlmIOEvent, ToolCallEvent
@@ -71,6 +72,15 @@ class TestCronNoApprover:
         assert "no interactive approver" in dec.reason
         # risk level is carried onto the escalated block for the API response
         assert getattr(dec, "_risk_level", None)
+
+        # The DURABLE audit record must reflect the escalation, not the
+        # superseded confirmation decision, and audit_id must point to it (#324).
+        records = engine.audit.get_session_records("s-cron")
+        assert records, "expected an audit record for the cron run"
+        rec = next((r for r in records if r.id == dec.audit_id), None)
+        assert rec is not None, "returned audit_id must point to a real record"
+        assert rec.constraint_step == STEP_CRON_NO_APPROVER
+        assert rec.decision == "blocked"
 
     def test_policy_unit_only_touches_confirmation_decisions(self, engine):
         """A plain allow/block decision is never altered by the cron policy."""
@@ -176,3 +186,59 @@ class TestLlmIOAudit:
         rec = json.loads(next((tmp_path / "audit").rglob("llm-sess-big.jsonl")).read_text().strip())
         assert rec["truncated"] is True
         assert len(rec["content"]) == 10_000
+
+
+# --- #315 review follow-ups: auth + input bounds on the durable LLM audit ---
+
+
+@pytest.fixture
+def client(tmp_path):
+    import safeclaw.main as main_module
+
+    config = SafeClawConfig(
+        data_dir=tmp_path,
+        ontology_dir=Path(__file__).parent.parent / "safeclaw" / "ontologies",
+        audit_dir=tmp_path / "audit",
+        dev_mode=True,
+    )
+    main_module.engine = FullEngine(config)
+    yield TestClient(main_module.app), main_module.engine
+    main_module.engine = None
+
+
+class TestLlmLogAuth:
+    def test_llm_log_rejects_bad_token_for_registered_agent(self, client):
+        c, engine = client
+        token = engine.agent_registry.register_agent("agent-llm", "developer", "sess-1")
+        for path in ("/api/v1/log/llm-input", "/api/v1/log/llm-output"):
+            # Wrong token for a registered agent -> 403, no record written.
+            bad = c.post(
+                path,
+                json={
+                    "sessionId": "s",
+                    "content": "x",
+                    "agentId": "agent-llm",
+                    "agentToken": "nope",
+                },
+            )
+            assert bad.status_code == 403, path
+            # Correct token -> accepted.
+            ok = c.post(
+                path,
+                json={
+                    "sessionId": "s",
+                    "content": "x",
+                    "agentId": "agent-llm",
+                    "agentToken": token,
+                },
+            )
+            assert ok.status_code == 200, path
+
+    def test_llm_log_rejects_oversized_usage(self, client):
+        c, _ = client
+        huge_usage = {f"k{i}": "v" * 1000 for i in range(200)}  # > params size bound
+        resp = c.post(
+            "/api/v1/log/llm-output",
+            json={"sessionId": "s", "content": "x", "usage": huge_usage},
+        )
+        assert resp.status_code == 422  # pydantic validation rejects before any write

--- a/safeclaw-service/tests/test_pr2_context_plumbing.py
+++ b/safeclaw-service/tests/test_pr2_context_plumbing.py
@@ -1,0 +1,178 @@
+"""PR-2: plugin->service context plumbing.
+
+Covers the cron trigger-origin escalation (#324), the new before_tool_call
+discriminator fields reaching the engine (#316 forwarding half), and the
+LLM I/O audit trail with provider/model/run/usage (#315 service side).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from safeclaw.config import SafeClawConfig
+from safeclaw.engine.core import Decision, LlmIOEvent, ToolCallEvent
+from safeclaw.engine.full_engine import STEP_CRON_NO_APPROVER, FullEngine
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = SafeClawConfig(
+        data_dir=tmp_path,
+        ontology_dir=Path(__file__).parent.parent / "safeclaw" / "ontologies",
+        audit_dir=tmp_path / "audit",
+    )
+    return FullEngine(config)
+
+
+# --- #324: cron trigger-origin escalation ---
+
+
+class TestCronNoApprover:
+    def test_interactive_confirmation_is_preserved(self, engine):
+        """An interactive run that needs confirmation stays needs-confirmation."""
+
+        async def run():
+            ev = ToolCallEvent(
+                session_id="s-int",
+                user_id="u",
+                tool_name="delete",
+                params={"file_path": "/tmp/a.txt"},
+                triggered_by="interactive",
+            )
+            return await engine.evaluate_tool_call(ev)
+
+        import asyncio
+
+        dec = asyncio.run(run())
+        assert dec.requires_confirmation is True
+        assert dec.constraint_step != STEP_CRON_NO_APPROVER
+
+    def test_cron_confirmation_escalates_to_block(self, engine):
+        """The same action on a cron run has no approver -> fail-safe block."""
+
+        async def run():
+            ev = ToolCallEvent(
+                session_id="s-cron",
+                user_id="u",
+                tool_name="delete",
+                params={"file_path": "/tmp/a.txt"},
+                triggered_by="cron",
+                job_id="job-42",
+            )
+            return await engine.evaluate_tool_call(ev)
+
+        import asyncio
+
+        dec = asyncio.run(run())
+        assert dec.block is True
+        assert dec.requires_confirmation is False
+        assert dec.constraint_step == STEP_CRON_NO_APPROVER
+        assert "no interactive approver" in dec.reason
+        # risk level is carried onto the escalated block for the API response
+        assert getattr(dec, "_risk_level", None)
+
+    def test_policy_unit_only_touches_confirmation_decisions(self, engine):
+        """A plain allow/block decision is never altered by the cron policy."""
+        allowed = Decision(block=False)
+        ev = ToolCallEvent(
+            session_id="s", user_id="u", tool_name="read", params={}, triggered_by="cron"
+        )
+        assert engine._apply_trigger_origin_policy(ev, allowed) is allowed
+
+        hard_block = Decision(block=True, reason="nope", requires_confirmation=False)
+        assert engine._apply_trigger_origin_policy(ev, hard_block) is hard_block
+
+    def test_no_trigger_origin_behaves_as_interactive(self, engine):
+        """Empty triggered_by (older plugins) must not escalate."""
+        confirm = Decision(block=True, requires_confirmation=True)
+        ev = ToolCallEvent(session_id="s", user_id="u", tool_name="delete", params={})
+        assert engine._apply_trigger_origin_policy(ev, confirm) is confirm
+
+
+# --- #316: before_tool_call discriminators reach the engine ---
+
+
+class TestToolCallDiscriminators:
+    def test_event_carries_discriminators(self):
+        ev = ToolCallEvent(
+            session_id="s",
+            user_id="u",
+            tool_name="exec",
+            params={},
+            tool_kind="code_mode_exec",
+            tool_input_kind="javascript",
+            derived_paths=["/work/a.ts", "/work/b.ts"],
+        )
+        assert ev.tool_kind == "code_mode_exec"
+        assert ev.tool_input_kind == "javascript"
+        assert ev.derived_paths == ["/work/a.ts", "/work/b.ts"]
+
+    def test_request_model_accepts_and_defaults(self):
+        from safeclaw.api.models import ToolCallRequest
+
+        bare = ToolCallRequest(toolName="read")
+        assert bare.toolKind == "" and bare.derivedPaths == [] and bare.triggeredBy == ""
+
+        full = ToolCallRequest(
+            toolName="exec",
+            toolKind="code_mode_exec",
+            toolInputKind="typescript",
+            derivedPaths=["/x"],
+            triggeredBy="cron",
+            jobId="j1",
+        )
+        assert full.toolInputKind == "typescript"
+        assert full.jobId == "j1"
+
+
+# --- #315: LLM I/O audit trail ---
+
+
+class TestLlmIOAudit:
+    def test_log_llm_io_writes_attributed_record(self, engine, tmp_path):
+        async def run():
+            await engine.log_llm_io(
+                LlmIOEvent(
+                    session_id="sess-llm",
+                    direction="output",
+                    content="hello world",
+                    provider="anthropic",
+                    model="claude-opus-4-8",
+                    run_id="run-7",
+                    usage={"input_tokens": 5, "output_tokens": 2},
+                )
+            )
+
+        import asyncio
+
+        asyncio.run(run())
+
+        files = list((tmp_path / "audit").rglob("llm-sess-llm.jsonl"))
+        assert len(files) == 1
+        rec = json.loads(files[0].read_text().strip())
+        assert rec["provider"] == "anthropic"
+        assert rec["model"] == "claude-opus-4-8"
+        assert rec["runId"] == "run-7"
+        assert rec["usage"] == {"input_tokens": 5, "output_tokens": 2}
+        assert rec["direction"] == "output"
+        assert rec["content"] == "hello world"
+        # owner-only permissions, like the decision audit log
+        assert (files[0].stat().st_mode & 0o777) == 0o600
+
+    def test_log_llm_io_truncates_long_content(self, engine, tmp_path):
+        async def run():
+            await engine.log_llm_io(
+                LlmIOEvent(
+                    session_id="sess-big",
+                    direction="input",
+                    content="x" * 20_000,
+                )
+            )
+
+        import asyncio
+
+        asyncio.run(run())
+        rec = json.loads(next((tmp_path / "audit").rglob("llm-sess-big.jsonl")).read_text().strip())
+        assert rec["truncated"] is True
+        assert len(rec["content"]) == 10_000


### PR DESCRIPTION
PR-2 of the OpenClaw v2026.6.8 upgrade series. Carries the new `before_tool_call` context from the plugin through the API into the engine, adds the cron trigger-origin policy, and the durable LLM I/O audit trail.

(Reopened against `main` — the original #334 was auto-closed when its stacked base branch #332 merged and was deleted. Rebased clean onto main; review fixes from that thread are included.)

Closes #315, #324. Part of #316.

## Changes
- **#324 — cron has no approver.** `triggeredBy`/`jobId` flow plugin → request → `ToolCallEvent`; a needs-confirmation decision on a cron run escalates to a fail-safe block. The escalation is applied inside `_log_decision` so the **durable audit record** (and its `audit_id`) reflect `constraint_step=cron_no_approver`, not the superseded confirmation.
- **#316 (forwarding half).** `toolKind`/`toolInputKind`/`derivedPaths` reach the classifier (consumption + param-rewrite land in PR-3).
- **#315 — LLM audit trail.** `LlmIORequest`/`LlmIOEvent` gain `runId`/`usage`; `log_llm_io` writes an attributed, owner-only (`0o600`) per-session `llm-<session>.jsonl`. Both `/log/llm-*` routes are **agent-token verified**, and `usage` is depth/size-bounded like `params`.

## Testing
- `tests/test_pr2_context_plumbing.py` — 10 tests (cron escalation incl. the durable-audit-record assertion, discriminator plumbing, LLM audit record, token rejection on both LLM routes, oversized-usage rejection).
- `python -m pytest tests/ -q` → **948 passed**
- `ruff check` / `ruff format --check` → clean; plugin `npm run typecheck`/`build` → clean.

## Review history (resolved in this branch)
- Cron escalation made truthful in the durable audit (was logging `preference_check`).
- `/log/llm-*` routes now token-verified (were unauthenticated despite persisting content).
- `usage` bounded (was an unbounded dict written under the audit lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)