### PR TITLE
chore(plugin): 2.0.1 — ClawHub publishing prep (compat metadata + SKILL.md)

### DIFF
--- a/openclaw-safeclaw-plugin/SKILL.md
+++ b/openclaw-safeclaw-plugin/SKILL.md
@@ -2,6 +2,9 @@
 
 SafeClaw validates every tool call, message, and agent action against OWL ontologies and SHACL constraints before execution. It acts as a governance gate between your AI agent and the tools it uses.
 
+> **Requires OpenClaw v2026.6.8 or newer.** The plugin reads v2026.6.8 hook
+> payloads; on older hosts governance data is incomplete.
+
 ## What it does
 
 - **Blocks dangerous actions** -- force push, deleting root, exposing secrets
@@ -23,6 +26,11 @@ SafeClaw validates every tool call, message, and agent action against OWL ontolo
 - `after_tool_call` -- records outcomes for dependency tracking
 - `subagent_spawning` / `subagent_ended` -- multi-agent governance
 - `session_start` / `session_end` -- session lifecycle tracking
+
+> The `llm_input`/`llm_output` audit hooks only fire when you grant raw
+> conversation access:
+> `plugins.entries.safeclaw.hooks.allowConversationAccess: true`. Without it the
+> LLM audit trail is silently empty.
 
 ## Agent tools
 

--- a/openclaw-safeclaw-plugin/openclaw.plugin.json
+++ b/openclaw-safeclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "safeclaw",
   "name": "SafeClaw Neurosymbolic Governance",
   "description": "Validates AI agent actions against OWL ontologies and SHACL constraints before execution",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Tendly EU",
   "license": "MIT",
   "homepage": "https://safeclaw.eu",
@@ -23,13 +23,21 @@
       },
       "enforcement": {
         "type": "string",
-        "enum": ["enforce", "warn-only", "audit-only", "disabled"],
+        "enum": [
+          "enforce",
+          "warn-only",
+          "audit-only",
+          "disabled"
+        ],
         "default": "enforce",
         "description": "Enforcement mode: enforce blocks violations, warn-only logs, audit-only records silently"
       },
       "failMode": {
         "type": "string",
-        "enum": ["open", "closed"],
+        "enum": [
+          "open",
+          "closed"
+        ],
         "default": "open",
         "description": "Behavior when service is unreachable: open allows actions, closed blocks them"
       },

--- a/openclaw-safeclaw-plugin/package-lock.json
+++ b/openclaw-safeclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-safeclaw-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-safeclaw-plugin",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.8.0",

--- a/openclaw-safeclaw-plugin/package.json
+++ b/openclaw-safeclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-safeclaw-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SafeClaw Neurosymbolic Governance plugin for OpenClaw — validates AI agent actions against OWL ontologies and SHACL constraints",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,15 @@
   "openclaw": {
     "extensions": [
       "dist/index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.6.8",
+      "minGatewayVersion": "2026.6.8"
+    },
+    "build": {
+      "openclawVersion": "2026.6.8",
+      "pluginSdkVersion": "2026.6.8"
+    }
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Updates the ClawHub listing source (`SKILL.md`) for the 2.0.0 release: states the **OpenClaw >=2026.6.8** requirement and the **`hooks.allowConversationAccess`** requirement for the LLM audit hooks. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)