### PR TITLE
docs: install via npm, not ClawHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SafeClaw/
 │   └── tests/                     # 500+ tests
 ├── openclaw-safeclaw-plugin/      # TypeScript bridge for OpenClaw
 │   ├── index.ts                   # Plugin hooks (~480 lines)
-│   └── SKILL.md                   # ClawHub distribution docs
+│   └── SKILL.md                   # Plugin overview (skill-format doc)
 └── safeclaw-landing/              # FastHTML landing site + user dashboard
     ├── main.py                    # Routes, docs page, landing page
     ├── db.py                      # SQLite user/key models

--- a/openclaw-safeclaw-plugin/README.md
+++ b/openclaw-safeclaw-plugin/README.md
@@ -4,13 +4,7 @@ Neurosymbolic governance plugin for OpenClaw AI agents. Validates every tool cal
 
 ## Installation
 
-### Via ClawHub (recommended)
-
-```bash
-openclaw plugins install safeclaw
-```
-
-### Manual install
+### Via npm (recommended)
 
 ```bash
 npm install -g openclaw-safeclaw-plugin
@@ -19,6 +13,8 @@ safeclaw-plugin restart-openclaw
 ```
 
 The `setup` command copies the plugin manifest to `~/.openclaw/extensions/safeclaw/` and enables it in `~/.openclaw/openclaw.json`. After install, restart OpenClaw to activate the plugin.
+
+> Install from npm (above) or from source (`git clone` + `npm install && npm run build` in `openclaw-safeclaw-plugin/`). This plugin is **not** on ClawHub — the `safeclaw` id there belongs to an unrelated third-party plugin, not this project.
 
 ## Quick Start
 


### PR DESCRIPTION
The plugin README recommended `openclaw plugins install safeclaw` — but the `safeclaw` id on ClawHub is owned by **unrelated third-party packages** (@kaillera999/safeclaw skill, @validance/safeclaw plugin), so that command installs the wrong thing.

- Promotes **npm** (`npm install -g openclaw-safeclaw-plugin`) to the recommended install, plus a from-source note.
- States plainly the project is **not on ClawHub** (the `safeclaw` id there is a third party).
- Fixes the root README file-tree comment for `SKILL.md`.

Context: we attempted to publish to ClawHub but "safeclaw" is claimed across every ClawHub field (skill name, plugin slug, and the global plugin **id**). Rather than a deep plugin-id rename, we're distributing via npm (`openclaw-safeclaw-plugin@2.0.0` is already live) + GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)